### PR TITLE
feat(docs): auto-refresh /releases page on GitHub Release events

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -16,6 +16,12 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs-build.yml'
+  # Refresh the /releases page whenever a new GitHub Release is
+  # published, edited, or deleted. The releases-loader plugin fetches
+  # the API at build time so the static page needs a rebuild for the
+  # new tag to show up.
+  release:
+    types: [published, edited, deleted, released]
   workflow_dispatch: {}
 
 # Allow one concurrent deployment; don't cancel an in-flight deploy when a
@@ -47,20 +53,34 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Build site
+        # GITHUB_TOKEN raises the GitHub Releases API rate limit from 60
+        # anonymous requests/hour to 5000 authenticated/hour. The
+        # releases-loader plugin reads it when present.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build
 
       - name: Verify build output
         run: test -f build/index.html
 
+      - name: Verify releases page built
+        run: test -f build/releases.html
+
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/docs/docs/releases-pipeline.md
+++ b/docs/docs/releases-pipeline.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 60
+title: Release pipeline
+---
+
+# Release pipeline
+
+How a new tag ends up on https://aws-samples.github.io/sample-oh-my-aidlcops/releases.
+
+```mermaid
+flowchart LR
+    A[git tag vX.Y.Z<br/>+ git push origin vX.Y.Z] --> B[release.yml]
+    B -->|foundation tests| C[build tarball]
+    C --> D[gh release create]
+    D -->|release: published event| E[docs-build.yml]
+    E -->|npm run build<br/>with GITHUB_TOKEN| F[releases-loader plugin<br/>fetches Releases API]
+    F --> G[build/releases.html regenerated]
+    G --> H[upload-pages-artifact]
+    H --> I[deploy-pages]
+    I --> J["Pages: /releases"]
+```
+
+## One-off authoring step
+
+```bash
+# From main, after PRs have merged:
+git tag v0.3.0-preview.1
+git push origin v0.3.0-preview.1
+```
+
+Everything after the push is automated. No CI secrets beyond the
+default `GITHUB_TOKEN` are required.
+
+## What each workflow does
+
+| Workflow | Trigger | Job | Purpose |
+|---|---|---|---|
+| [`release.yml`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/.github/workflows/release.yml) | `push` tag `v*` | foundation tests | Python + bats smoke before we ship |
+| `release.yml` | same | build tarball | `scripts/dev/make-tarball.sh` |
+| `release.yml` | same | publish GitHub Release | `gh release create` with CHANGELOG body + tarball + `.sha256` |
+| [`docs-build.yml`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/.github/workflows/docs-build.yml) | `release: published` | Build | `npm run build` — runs the `releases-loader` plugin, which fetches `/repos/OWNER/REPO/releases` at build time |
+| `docs-build.yml` | same | Deploy to GitHub Pages | `actions/deploy-pages@v4` |
+
+## Rollback
+
+If a release is published in error:
+
+1. `gh release delete vX.Y.Z --cleanup-tag` — removes the GitHub
+   Release and the tag.
+2. `docs-build.yml` rebuilds automatically on the `release: deleted`
+   event, so `/releases` loses the entry without a manual redeploy.
+3. If the site needs a forced rebuild with no release event, use the
+   `workflow_dispatch` button on the `docs` workflow page.
+
+## Why a build-time plugin?
+
+The `releases-loader` plugin calls the public GitHub Releases API
+*while the site is being compiled*, then bakes the response into a
+static JSON file that the `/releases` page imports via
+`usePluginData`. This design has three benefits:
+
+- **No runtime dependency** on api.github.com. Pages stays available
+  even if GitHub is degraded.
+- **No CORS plumbing.** The JSON is served from the same origin as
+  the rest of the site.
+- **Rate limits are handled once.** CI builds with
+  `GITHUB_TOKEN` (5000 req/h), so we never hit the 60 req/h
+  anonymous cap. Local dev works without a token because 60 req/h
+  is more than enough for interactive iteration.
+
+When the API is unreachable at build time, the plugin logs a warning
+and emits an empty list; the build succeeds and the page renders a
+"no releases captured" notice with a link to the live source.
+
+## Manual refresh
+
+If you want to force a Pages rebuild without a new tag:
+
+- **Actions UI**: open the `docs` workflow, click *Run workflow*,
+  pick the `main` branch.
+- **gh CLI**:
+  ```bash
+  gh workflow run docs --repo aws-samples/sample-oh-my-aidlcops
+  ```

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -16,6 +16,18 @@ const config: Config = {
   },
   themes: ['@docusaurus/theme-mermaid'],
 
+  // Custom plugin: fetches GitHub Releases at build time so /releases
+  // always reflects the latest published tag without a runtime API call.
+  plugins: [
+    [
+      require.resolve('./plugins/releases-loader'),
+      {
+        repo: 'aws-samples/sample-oh-my-aidlcops',
+        perPage: 20,
+      },
+    ],
+  ],
+
   // Production URL + baseUrl (GitHub Pages).
   url: 'https://aws-samples.github.io',
   baseUrl: '/sample-oh-my-aidlcops/',

--- a/docs/plugins/releases-loader/index.ts
+++ b/docs/plugins/releases-loader/index.ts
@@ -1,0 +1,117 @@
+/**
+ * releases-loader — Docusaurus plugin that fetches GitHub Releases at
+ * build time and exposes them to the Releases page as a static data file.
+ *
+ * The plugin runs unauthenticated against the public API. GitHub Actions
+ * may supply a token via GITHUB_TOKEN / OMA_RELEASES_TOKEN to raise the
+ * anonymous rate limit from 60 req/h to 5000 req/h on the official
+ * runners.
+ *
+ * If the API is unreachable at build time (offline dev, rate limit), the
+ * plugin emits an empty list and logs a warning rather than failing the
+ * build — the site keeps working with a "no releases yet" notice.
+ */
+
+import type { LoadContext, Plugin } from '@docusaurus/types';
+
+export interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+export interface ReleaseRecord {
+  tag_name: string;
+  name: string;
+  published_at: string | null;
+  html_url: string;
+  prerelease: boolean;
+  draft: boolean;
+  body: string;
+  assets: ReleaseAsset[];
+}
+
+interface PluginOptions {
+  repo: string;     // "owner/name"
+  perPage?: number; // default 20
+}
+
+const API_BASE = 'https://api.github.com';
+
+async function fetchReleases(repo: string, perPage: number): Promise<ReleaseRecord[]> {
+  const token = process.env.GITHUB_TOKEN || process.env.OMA_RELEASES_TOKEN;
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'oma-docs-release-loader',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const url = `${API_BASE}/repos/${repo}/releases?per_page=${perPage}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub Releases API returned ${res.status} ${res.statusText} for ${repo}`,
+    );
+  }
+  const data = (await res.json()) as Array<Record<string, unknown>>;
+  return data.map((r) => ({
+    tag_name: String(r.tag_name ?? ''),
+    name: String(r.name ?? r.tag_name ?? ''),
+    published_at: (r.published_at as string | null) ?? null,
+    html_url: String(r.html_url ?? ''),
+    prerelease: Boolean(r.prerelease),
+    draft: Boolean(r.draft),
+    body: String(r.body ?? ''),
+    assets: Array.isArray(r.assets)
+      ? (r.assets as Array<Record<string, unknown>>).map((a) => ({
+          name: String(a.name ?? ''),
+          browser_download_url: String(a.browser_download_url ?? ''),
+          size: Number(a.size ?? 0),
+        }))
+      : [],
+  }));
+}
+
+export default function releasesLoaderPlugin(
+  _context: LoadContext,
+  options: PluginOptions,
+): Plugin<{ releases: ReleaseRecord[]; fetchedAt: string; source: string }> {
+  const { repo, perPage = 20 } = options;
+  if (!repo || !/^[^/]+\/[^/]+$/.test(repo)) {
+    throw new Error(`releases-loader: invalid repo option ${JSON.stringify(repo)}`);
+  }
+
+  return {
+    name: 'releases-loader',
+
+    async loadContent() {
+      const fetchedAt = new Date().toISOString();
+      try {
+        const releases = await fetchReleases(repo, perPage);
+        // Skip drafts; consumer UI shows pre-releases with a badge.
+        const visible = releases.filter((r) => !r.draft);
+        return { releases: visible, fetchedAt, source: repo };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[releases-loader] failed to fetch ${repo} releases (${msg}); ` +
+          `building with an empty list`,
+        );
+        return { releases: [], fetchedAt, source: repo };
+      }
+    },
+
+    async contentLoaded({ content, actions }) {
+      const { createData, setGlobalData } = actions;
+      // createData writes a static JSON file available to pages via the
+      // standard static-site data channel; setGlobalData exposes the same
+      // payload to any component via useGlobalData().
+      await createData('releases.json', JSON.stringify(content, null, 2));
+      setGlobalData(content);
+    },
+  };
+}

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'support-policy',
         'telemetry',
+        'releases-pipeline',
       ],
     },
     {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -61,6 +61,11 @@ const sidebars: SidebarsConfig = {
         'telemetry',
       ],
     },
+    {
+      type: 'link',
+      label: 'Releases',
+      href: '/releases',
+    },
   ],
 };
 

--- a/docs/src/pages/releases.tsx
+++ b/docs/src/pages/releases.tsx
@@ -1,0 +1,168 @@
+/**
+ * /releases — static page rendered from the snapshot that
+ * plugins/releases-loader fetches at build time.
+ *
+ * Re-build the site to refresh the list. docs-build.yml triggers on
+ * `release.published` so a new GitHub Release automatically rebuilds
+ * and redeploys the Pages site.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import { usePluginData } from '@docusaurus/useGlobalData';
+import type { ReleaseRecord } from '../../plugins/releases-loader';
+
+interface LoaderData {
+  releases: ReleaseRecord[];
+  fetchedAt: string;
+  source: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return `${n.toFixed(n < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+export default function ReleasesPage(): React.ReactElement {
+  const data = usePluginData('releases-loader') as LoaderData | undefined;
+  const releases = data?.releases ?? [];
+  const fetchedAt = data?.fetchedAt ?? '';
+  const source = data?.source ?? '';
+
+  return (
+    <Layout
+      title="Releases"
+      description="OMA tech-preview releases, published when a v* tag ships."
+    >
+      <main className="container margin-vert--lg">
+        <h1>Releases</h1>
+        <p>
+          Tech-preview builds of <code>oh-my-aidlcops</code>. Each release ships
+          a reproducible tarball plus a <code>.sha256</code> checksum. See the
+          individual release pages on GitHub for the full changelog and signed
+          assets.
+        </p>
+
+        <p style={{ color: 'var(--ifm-color-emphasis-600)', fontSize: '0.9rem' }}>
+          Data source:{' '}
+          <Link to={`https://github.com/${source}/releases`}>
+            github.com/{source}/releases
+          </Link>
+          {fetchedAt ? (
+            <>
+              {' · '}snapshot built {formatDate(fetchedAt)}
+            </>
+          ) : null}
+          {' · '}
+          <Link to="https://github.com/aws-samples/sample-oh-my-aidlcops/subscription">
+            watch for new releases
+          </Link>
+        </p>
+
+        {releases.length === 0 ? (
+          <div
+            className="alert alert--info"
+            role="alert"
+            style={{ marginTop: '1.5rem' }}
+          >
+            No releases captured in this build. Either the API was unreachable
+            at build time, or no tag has been pushed yet. Check the source link
+            above for the live list.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            {releases.map((r) => (
+              <article
+                key={r.tag_name}
+                style={{
+                  border: '1px solid var(--ifm-color-emphasis-300)',
+                  borderRadius: '0.5rem',
+                  padding: '1rem 1.25rem',
+                  background: 'var(--ifm-background-surface-color)',
+                }}
+              >
+                <header
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'baseline',
+                    gap: '0.75rem',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <h2 style={{ marginBottom: 0 }}>
+                    <Link to={r.html_url}>{r.name || r.tag_name}</Link>
+                    {r.prerelease ? (
+                      <span
+                        className="badge badge--warning"
+                        style={{ marginLeft: '0.75rem', verticalAlign: 'middle' }}
+                      >
+                        pre-release
+                      </span>
+                    ) : null}
+                  </h2>
+                  <span style={{ color: 'var(--ifm-color-emphasis-700)' }}>
+                    {formatDate(r.published_at)} · {r.tag_name}
+                  </span>
+                </header>
+
+                {r.body ? (
+                  <details style={{ marginTop: '0.75rem' }}>
+                    <summary style={{ cursor: 'pointer' }}>Release notes</summary>
+                    <pre
+                      style={{
+                        whiteSpace: 'pre-wrap',
+                        background: 'var(--ifm-color-emphasis-100)',
+                        padding: '0.75rem 1rem',
+                        borderRadius: '0.25rem',
+                        marginTop: '0.5rem',
+                      }}
+                    >
+                      {r.body}
+                    </pre>
+                  </details>
+                ) : null}
+
+                {r.assets.length > 0 ? (
+                  <div style={{ marginTop: '0.75rem' }}>
+                    <strong>Assets</strong>
+                    <ul>
+                      {r.assets.map((a) => (
+                        <li key={a.browser_download_url}>
+                          <Link to={a.browser_download_url}>{a.name}</Link>
+                          {a.size ? (
+                            <span
+                              style={{
+                                color: 'var(--ifm-color-emphasis-600)',
+                                marginLeft: '0.5rem',
+                              }}
+                            >
+                              ({formatBytes(a.size)})
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        )}
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Close the loop between `release.yml` and GitHub Pages so a tag push
propagates to https://aws-samples.github.io/sample-oh-my-aidlcops/releases
without any manual steps.

Three focused commits:

1. **`feat(docs)`** — add a Docusaurus `releases-loader` plugin and
   a `/releases` React page. The plugin calls the public Releases
   REST API once at build time, authenticating with `GITHUB_TOKEN`
   when available, and bakes the response into a static page with
   pre-release badges, release notes, and downloadable assets.
2. **`ci(docs)`** — trigger `docs-build.yml` on `release` events
   (`published` / `edited` / `deleted` / `released`), pass
   `GITHUB_TOKEN` into the build step, add a smoke check that
   `build/releases.html` exists, and let the deploy job fire on
   `release` and `workflow_dispatch` in addition to `push` to main.
3. **`docs`** — `docs/docs/releases-pipeline.md` documents the
   end-to-end flow, rollback procedure, and manual-refresh options,
   with a Mermaid diagram of the automation.

## Pipeline after this PR

```
git push origin vX.Y.Z
  -> release.yml: foundation tests -> build tarball -> gh release create
     -> release: published event
        -> docs-build.yml: npm run build (releases-loader fetches API)
           -> deploy-pages -> /releases shows the new entry
```

No new secrets required. `GITHUB_TOKEN` is the default permission
GitHub Actions already provides.

## Test plan

- [x] Local `npm run build` in `docs/` — both `ko` and `en` locales
  build cleanly and include the current `v0.2.0-preview.1` release
  with its tarball + `.sha256` asset links.
- [x] `build/releases.html` + `build/en/releases.html` render the
  plugin's fetched data (release name, published-at date, notes,
  assets with sizes).
- [x] Mermaid diagram in `releases-pipeline.md` renders under
  Docusaurus's `theme-mermaid`.
- [ ] CI `foundation`, `Validate Schemas`, `Evaluate Skills`, and
  `docs/Build` on this branch.
- [ ] End-to-end proof comes with the next `v*` tag push; the
  rollback section documents how to recover if the `release` event
  is missed for any reason.

## Files changed

- `docs/plugins/releases-loader/index.ts` (NEW, 117 lines)
- `docs/src/pages/releases.tsx` (NEW, 168 lines)
- `docs/docusaurus.config.ts` (+12 lines — plugins registration)
- `docs/sidebars.ts` (+6 lines — Releases link + pipeline doc)
- `docs/docs/releases-pipeline.md` (NEW)
- `.github/workflows/docs-build.yml` (release trigger, token, deploy conditions)

## Rollback

`docs/docs/releases-pipeline.md` covers the rollback procedure:
`gh release delete vX.Y.Z --cleanup-tag` triggers `release: deleted`
which rebuilds the site with the entry removed, no manual action
required.