### PR TITLE
fix(deps): override transitive uuid to 14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17874,15 +17874,6 @@
         "websocket-driver": "^0.7.4"
       }
     },
-    "node_modules/sockjs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/sort-css-media-queries": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
@@ -18983,16 +18974,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,8 @@
   "overrides": {
     "serialize-javascript": "7.0.5",
     "webpack-dev-server": "5.2.3",
-    "webpack": "5.105.1"
+    "webpack": "5.105.1",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #1 (`GHSA-w5hq-g745-h8pq` — "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided", medium severity) by pinning the transitive `uuid` dependency under `docs/` to `^14.0.0` via npm `overrides`.

## Why this minimal fix

Docusaurus 3.9.2 pulls `uuid` transitively:

```
@docusaurus/core@3.9.2
└─ webpack-dev-server@5.2.3 (already overridden here)
   └─ sockjs@0.3.24
      └── uuid   (pre-14 → flagged)

@docusaurus/theme-mermaid@3.9.2
└─ mermaid@11.14.0
   └── uuid   (pre-14 → flagged)
```

We never import `uuid` directly, and the exploit path requires a caller-supplied `buf` argument — which neither Docusaurus nor the `releases-loader` plugin uses. So the alert is low-impact on our side, but pinning transitively is the cheapest way to clear it without waiting on Docusaurus's own bump.

Upgrading Docusaurus 3.9.2 → 3.10.x was rejected because the project downgraded from 3.10.0 on 2026-04-30 due to webpack `ProgressPlugin` regressions (see commit `e5ba1bc`).

## Change

- `docs/package.json` — add `"uuid": "^14.0.0"` to the existing `overrides` block alongside `webpack` / `webpack-dev-server` / `serialize-javascript` pins.
- `docs/package-lock.json` — regenerated by `npm install`. Both `sockjs` and `mermaid` now dedupe onto `uuid@14.0.0`.

## Test plan

- [x] `npm run build` in `docs/` — both `ko` and `en` locales build cleanly.
- [x] `npm ls uuid` confirms only `uuid@14.0.0` appears in the tree (two transitive consumers, one deduped).
- [x] `/releases` page still renders (releases-loader plugin unaffected).
- [x] Mermaid diagrams still render (mermaid 11.14.0 works with uuid 14 via the override).
- [ ] CI `docs/Build` on this branch.

## Files changed

- `docs/package.json` (+1 line inside existing overrides)
- `docs/package-lock.json` (net −8 lines after dedupe)