### PR TITLE
feat(oma-validate): extend to Spec/ADR/Risk/Incident/Budget entities

### DIFF
--- a/scripts/oma/validate.sh
+++ b/scripts/oma/validate.sh
@@ -58,33 +58,73 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 python3 - "$OMA_ROOT" "$ENTITY_FILE" <<'PY'
-import json, sys
+import json, sys, re
 from pathlib import Path
 
 import yaml
-from jsonschema import Draft7Validator, RefResolver
+from jsonschema import Draft7Validator, Draft202012Validator, RefResolver
 
 repo_root = Path(sys.argv[1])
 entity_path = Path(sys.argv[2])
 
 data = yaml.safe_load(entity_path.read_text(encoding="utf-8"))
-# Heuristic: Deployment has target/artifact/approval_state.
+
+# Entity type detection heuristics (order matters for specificity)
 schema_name = None
-if isinstance(data, dict) and {"target", "artifact", "approval_state"} <= set(data):
-    schema_name = "deployment.schema.json"
+validator_class = Draft7Validator
+
+if isinstance(data, dict):
+    entity_id = data.get("id", "")
+    top_keys = set(data.keys())
+
+    # Spec: id matches ^spec-[a-z0-9-]+$ (Draft 2020-12)
+    if re.match(r"^spec-[a-z0-9-]+$", entity_id):
+        schema_name = "spec.schema.json"
+        validator_class = Draft202012Validator
+    # ADR: id matches ^adr-[0-9]{4}-[a-z0-9-]+$ (Draft 2020-12)
+    elif re.match(r"^adr-[0-9]{4}-[a-z0-9-]+$", entity_id):
+        schema_name = "adr.schema.json"
+        validator_class = Draft202012Validator
+    # Deployment: has target + artifact + approval_state (Draft-07)
+    elif {"target", "artifact", "approval_state"} <= top_keys:
+        schema_name = "deployment.schema.json"
+    # Incident: has severity + alarm_source (Draft-07)
+    elif {"severity", "alarm_source"} <= top_keys:
+        schema_name = "incident.schema.json"
+    # Budget: has scope + limit_usd (Draft-07)
+    elif {"scope", "limit_usd"} <= top_keys:
+        schema_name = "budget.schema.json"
+    # Risk: has category + likelihood + impact (Draft-07)
+    elif {"category", "likelihood", "impact"} <= top_keys:
+        schema_name = "risk.schema.json"
+    # Agent: has runtime (Draft-07)
+    elif "runtime" in top_keys and re.match(r"^[a-z][a-z0-9-]*$", entity_id):
+        schema_name = "agent.schema.json"
+    # Skill: has harness (Draft-07)
+    elif "harness" in top_keys:
+        schema_name = "skill.schema.json"
+
 if schema_name is None:
     print(f"[oma validate] cannot infer entity type for {entity_path}; "
-          "only Deployment schema is wired in v0.4.", file=sys.stderr)
+          "supported: Deployment/Incident/Budget/Risk/Agent/Skill/Spec/ADR", file=sys.stderr)
     sys.exit(0)
 
 schema_dir = repo_root / "schemas" / "ontology"
+common_dir = repo_root / "schemas" / "common"
 schema = json.loads((schema_dir / schema_name).read_text(encoding="utf-8"))
+
+# Build ref store with ontology and common schemas
 store = {}
 for other in schema_dir.glob("*.schema.json"):
     content = json.loads(other.read_text(encoding="utf-8"))
     store[content["$id"]] = content
     store[other.name] = content
-validator = Draft7Validator(schema, resolver=RefResolver.from_schema(schema, store=store))
+for common in common_dir.glob("*.schema.json"):
+    content = json.loads(common.read_text(encoding="utf-8"))
+    store[content["$id"]] = content
+    store[common.name] = content
+
+validator = validator_class(schema, resolver=RefResolver.from_schema(schema, store=store))
 errs = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
 if errs:
     print(f"[oma validate] {entity_path}: {len(errs)} schema violation(s)", file=sys.stderr)

--- a/tests/harness/test_validate_entities.py
+++ b/tests/harness/test_validate_entities.py
@@ -1,0 +1,311 @@
+"""Multi-entity validation tests for scripts/oma/validate.sh.
+
+Covers all 8 ontology entity types: Deployment, Incident, Budget, Risk,
+Agent, Skill, Spec, ADR. Each entity gets a positive case (valid minimal
+fixture) and a negative case (schema violation).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_SH = REPO_ROOT / "scripts" / "oma" / "validate.sh"
+
+
+def _run(args: list[str], cwd: Path | None = None, env: dict[str, str] | None = None):
+    """Run validate.sh with the current python in PATH so jsonschema/pyyaml are importable."""
+    import sys as _sys
+    py_dir = str(Path(_sys.executable).parent)
+    merged_env = {**os.environ, **(env or {})}
+    merged_env["PATH"] = py_dir + os.pathsep + merged_env.get("PATH", "")
+    return subprocess.run(
+        ["bash", str(VALIDATE_SH), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd or REPO_ROOT),
+        env=merged_env,
+    )
+
+
+def _write_yaml(tmp_path: Path, filename: str, doc: dict) -> Path:
+    out = tmp_path / filename
+    out.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    return out
+
+
+# ========== Deployment ==========
+
+
+def test_deployment_valid(tmp_path):
+    doc = {
+        "id": "vllm-llama3-70b",
+        "target": "eks",
+        "artifact": "public.ecr.aws/example/vllm:0.18.2",
+        "approval_state": "proposed",
+    }
+    path = _write_yaml(tmp_path, "deployment.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_deployment_invalid_target(tmp_path):
+    doc = {
+        "id": "test-deploy",
+        "target": "mainframe",  # not in enum
+        "artifact": "foo",
+        "approval_state": "proposed",
+    }
+    path = _write_yaml(tmp_path, "deployment.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Incident ==========
+
+
+def test_incident_valid(tmp_path):
+    doc = {
+        "id": "inc-2024-001",
+        "severity": "sev-2",
+        "alarm_source": "CloudWatch:CPUUtilization",
+        "approval_state": "draft",
+    }
+    path = _write_yaml(tmp_path, "incident.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_incident_invalid_severity(tmp_path):
+    doc = {
+        "id": "inc-bad",
+        "severity": "sev-99",  # not in enum
+        "alarm_source": "test",
+        "approval_state": "draft",
+    }
+    path = _write_yaml(tmp_path, "incident.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Budget ==========
+
+
+def test_budget_valid(tmp_path):
+    doc = {
+        "id": "budget-dev-team",
+        "scope": "account",
+        "limit_usd": 1000.0,
+        "period": "monthly",
+        "rule_expression": "spend_usd > limit_usd * 0.9",
+        "action_on_breach": "notify",
+    }
+    path = _write_yaml(tmp_path, "budget.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_budget_invalid_period(tmp_path):
+    doc = {
+        "id": "budget-bad",
+        "scope": "account",
+        "limit_usd": 500.0,
+        "period": "annually",  # not in enum
+        "rule_expression": "true",
+        "action_on_breach": "notify",
+    }
+    path = _write_yaml(tmp_path, "budget.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Risk ==========
+
+
+def test_risk_valid(tmp_path):
+    doc = {
+        "id": "risk-data-loss",
+        "category": "security",
+        "likelihood": "medium",
+        "impact": "major",
+    }
+    path = _write_yaml(tmp_path, "risk.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_risk_invalid_category(tmp_path):
+    doc = {
+        "id": "risk-bad",
+        "category": "unknown-category",  # not in enum
+        "likelihood": "low",
+        "impact": "minor",
+    }
+    path = _write_yaml(tmp_path, "risk.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Agent ==========
+
+
+def test_agent_valid(tmp_path):
+    doc = {
+        "id": "test-agent",
+        "runtime": "claude-code",
+    }
+    path = _write_yaml(tmp_path, "agent.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_agent_invalid_runtime(tmp_path):
+    doc = {
+        "id": "bad-agent",
+        "runtime": "unknown-runtime",  # not in enum
+    }
+    path = _write_yaml(tmp_path, "agent.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Skill ==========
+
+
+def test_skill_valid(tmp_path):
+    doc = {
+        "id": "test-skill",
+        "harness": "claude",
+    }
+    path = _write_yaml(tmp_path, "skill.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_skill_invalid_harness(tmp_path):
+    doc = {
+        "id": "bad-skill",
+        "harness": "unsupported",  # not in enum
+    }
+    path = _write_yaml(tmp_path, "skill.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Spec (Draft 2020-12) ==========
+
+
+def test_spec_valid(tmp_path):
+    doc = {
+        "id": "spec-user-auth",
+        "owner": "platform-team",
+        "status": "draft",
+    }
+    path = _write_yaml(tmp_path, "spec.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_spec_invalid_id_pattern(tmp_path):
+    """An id that does not match ^spec-...$ fails entity detection
+    (by design) and falls back to the unknown-entity path with exit 0.
+    Once inside the Spec path, an invalid status/required field DOES
+    trigger a schema violation — see test_spec_invalid_status below."""
+    doc = {
+        "id": "invalid-id-no-prefix",
+        "owner": "team",
+        "status": "draft",
+    }
+    path = _write_yaml(tmp_path, "spec.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0
+    assert "cannot infer entity type" in result.stderr
+
+
+def test_spec_invalid_status(tmp_path):
+    doc = {
+        "id": "spec-demo-feature",
+        "owner": "team",
+        "status": "publishing",  # not in {draft, reviewing, approved, superseded}
+    }
+    path = _write_yaml(tmp_path, "spec.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== ADR (Draft 2020-12) ==========
+
+
+def test_adr_valid(tmp_path):
+    doc = {
+        "id": "adr-0001-use-eks",
+        "status": "accepted",
+        "title": "Use EKS for container orchestration",
+        "context": "We need a managed Kubernetes service.",
+        "decision": "We will use Amazon EKS.",
+    }
+    path = _write_yaml(tmp_path, "adr.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0, result.stderr
+    assert "schema OK" in result.stdout
+
+
+def test_adr_invalid_id_pattern(tmp_path):
+    """ADR detection requires id matching ^adr-NNNN-...$. Non-matching
+    ids miss detection and fall back to the unknown-entity path."""
+    doc = {
+        "id": "adr-1-wrong",
+        "status": "accepted",
+        "title": "Test",
+        "context": "Context",
+        "decision": "Decision",
+    }
+    path = _write_yaml(tmp_path, "adr.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0
+    assert "cannot infer entity type" in result.stderr
+
+
+def test_adr_invalid_status(tmp_path):
+    doc = {
+        "id": "adr-0001-use-eks",
+        "status": "inked",  # not in {proposed, accepted, rejected, deprecated, superseded}
+        "title": "Use EKS",
+        "context": "Ctx",
+        "decision": "Dec",
+    }
+    path = _write_yaml(tmp_path, "adr.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 1
+    assert "schema violation" in result.stderr
+
+
+# ========== Fallback: unrecognized entity ==========
+
+
+def test_unrecognized_entity_exits_zero_with_warning(tmp_path):
+    doc = {"foo": "bar", "random": "data"}
+    path = _write_yaml(tmp_path, "unknown.yaml", doc)
+    result = _run([str(path)])
+    assert result.returncode == 0
+    assert "cannot infer entity type" in result.stderr
+    assert "Deployment/Incident/Budget/Risk/Agent/Skill/Spec/ADR" in result.stderr


### PR DESCRIPTION
## Summary

`oma validate` previously only handled Deployment; every other ontology entity slipped through with a silent warning. This PR routes on entity shape for all 8 types and selects the correct validator draft (Draft-07 for the legacy six, Draft 2020-12 for Spec/ADR).

Part of the v0.3→v0.5 follow-up wave (W3 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Routing table

| Entity | Heuristic | Schema draft |
|---|---|---|
| Deployment | top-level `target` + `artifact` + `approval_state` | Draft-07 |
| Incident | top-level `severity` + `alarm_source` | Draft-07 |
| Budget | top-level `scope` + `limit_usd` | Draft-07 |
| Risk | top-level `category` + `likelihood` + `impact` | Draft-07 |
| Agent | top-level `runtime` | Draft-07 |
| Skill | top-level `harness` | Draft-07 |
| Spec | `id` matches `^spec-...$` | Draft 2020-12 |
| ADR | `id` matches `^adr-NNNN-...$` | Draft 2020-12 |

## Commits

- `feat(oma-validate): route on entity shape for the 8 ontology types`
- `test(oma-validate): cover every entity type with fixture + subprocess`

## Test plan

- [x] `pytest tests/ --ignore=tests/installer --ignore=tests/profile --ignore=tests/hooks --ignore=tests/doctor -q` → **106 passed** (87 baseline + 19 new).

## Files changed

- `scripts/oma/validate.sh`
- `tests/harness/test_validate_entities.py` (new)