### PR TITLE
feat(harness): populate workflows/telemetry/policies on agentic-platform + stub run-workflow.sh

### DIFF
--- a/bin/oma
+++ b/bin/oma
@@ -57,6 +57,7 @@ Subcommands:
     doctor      Run 12 environment probes; exit 0 all-pass / 1 warn / 2 fail.
     compile     Compile every plugin's *.oma.yaml into native .mcp.json / agent.json files.
     validate    Validate a Deployment YAML against the ontology + active OPA policies.
+    run-workflow Resolve and print workflow DAG execution plan (stub: no invocation yet).
     status      Read .omao/profile.yaml and summarize active mode, budgets, last doctor.
     where       Print the OMA install root and key subdirectories.
     upgrade     git pull + re-run setup --migrate (clone installs only).

--- a/plugins/agentic-platform/agentic-platform.oma.yaml
+++ b/plugins/agentic-platform/agentic-platform.oma.yaml
@@ -15,6 +15,8 @@ plugin: agentic-platform
 metadata:
   labels:
     aidlc-phase: construction
+    cost-tier: high
+    compliance-required: "true"
 
 # ---------------------------------------------------------------------------
 # MCP servers (pinned to exact PyPI versions for supply-chain safety)
@@ -161,6 +163,49 @@ agents:
 hooks:
   session-start:
     runs: ../../hooks/session-start.sh
+
+# ---------------------------------------------------------------------------
+# Keyword triggers (merged into .omao/triggers.json by the compiler).
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Workflows (v2) — DAG-based execution plans validated at compile time.
+# ---------------------------------------------------------------------------
+workflows:
+  platform-bootstrap:
+    description: "Full EKS + GPU + vLLM + Langfuse bootstrap with preflight checks and rollback."
+    steps:
+      - id: preflight
+        agent_ref: agentic-platform
+      - id: provision
+        agent_ref: agentic-platform
+        depends_on: [preflight]
+        on_failure: rollback
+      - id: verify
+        skill_ref: agentic-eks-bootstrap
+        depends_on: [provision]
+
+# ---------------------------------------------------------------------------
+# Telemetry (v2) — OpenTelemetry endpoints for traces, metrics, logs.
+# ---------------------------------------------------------------------------
+telemetry:
+  traces:
+    endpoint: http://langfuse.ops.svc.cluster.local:4317
+    protocol: grpc
+    sampler: parentbased_traceidratio
+    sampler_ratio: 0.1
+  metrics:
+    endpoint: http://otel-collector.ops.svc.cluster.local:4318
+    interval_seconds: 30
+
+# ---------------------------------------------------------------------------
+# Policies (v2) — OPA policy references checked at compile time.
+# ---------------------------------------------------------------------------
+policies:
+  - id: require-approval-for-prod
+    rego_ref: policies/examples/deployment-approval.rego
+    severity: blocking
+    phase: [construction, operations]
+    description: "Enforce non-empty approval_chain for production deployments."
 
 # ---------------------------------------------------------------------------
 # Keyword triggers (merged into .omao/triggers.json by the compiler).

--- a/scripts/oma/run-workflow.sh
+++ b/scripts/oma/run-workflow.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# scripts/oma/run-workflow.sh — OMA workflow DAG runner (stub: prints plan, does not execute).
+#
+# Usage:
+#   oma run-workflow <plugin> <workflow-name>
+#
+# Resolves the plugin's *.oma.yaml, extracts the named workflow, topo-sorts
+# the DAG (Kahn's algorithm), and prints the execution order with agent_ref/skill_ref
+# per step. Validates that agent_ref points at a declared agent. Exits 0 on clean DAG,
+# 1 on missing workflow / cycle / unknown agent_ref.
+#
+# Future work: layer actual invocation (spawn agent, execute skill, pass context).
+
+set -euo pipefail
+
+OMA_REPO_ROOT="${OMA_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck disable=SC1091
+. "$OMA_REPO_ROOT/scripts/lib/log.sh"
+
+usage() {
+    cat <<EOF
+Usage: oma run-workflow <plugin> <workflow-name>
+
+Validates and prints the DAG execution plan for a named workflow.
+
+Example:
+    oma run-workflow agentic-platform platform-bootstrap
+
+Environment:
+    OMA_REPO_ROOT   Override repo root (default: auto-detect).
+    OMA_DRY_RUN     Print plan but exit before invoking agents (default: already dry).
+EOF
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    exit 64  # EX_USAGE
+fi
+
+plugin_name="$1"
+workflow_name="$2"
+
+dsl_path="$OMA_REPO_ROOT/plugins/$plugin_name/$plugin_name.oma.yaml"
+if [ ! -f "$dsl_path" ]; then
+    die "plugin '$plugin_name' not found (expected $dsl_path)"
+    exit 1
+fi
+
+# Require python3 + pyyaml.
+if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 not found; install it to run workflow DAG resolution"
+    exit 1
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    die "python3 package 'pyyaml' not found; install via: pip3 install pyyaml"
+    exit 1
+fi
+
+# Inline Python script: load YAML, extract workflow, topo-sort, print execution order.
+python3 - "$dsl_path" "$workflow_name" <<'EOPYTHON'
+import sys
+import yaml
+from collections import defaultdict, deque
+
+dsl_path = sys.argv[1]
+workflow_name = sys.argv[2]
+
+with open(dsl_path, 'r', encoding='utf-8') as fh:
+    dsl = yaml.safe_load(fh)
+
+if not isinstance(dsl, dict):
+    print(f"error: {dsl_path} top-level must be a mapping", file=sys.stderr)
+    sys.exit(1)
+
+workflows = dsl.get('workflows') or {}
+if workflow_name not in workflows:
+    if not workflows:
+        print(f"error: plugin {dsl.get('plugin', '?')} declares no workflows", file=sys.stderr)
+    else:
+        available = ', '.join(workflows.keys())
+        print(f"error: workflow '{workflow_name}' not found (available: {available})", file=sys.stderr)
+    sys.exit(1)
+
+workflow = workflows[workflow_name]
+steps = workflow.get('steps') or []
+if not steps:
+    print(f"error: workflow '{workflow_name}' has no steps", file=sys.stderr)
+    sys.exit(1)
+
+# Build step map and validate agent_ref resolution.
+agent_ids = {a['id'] for a in (dsl.get('agents') or [])}
+step_map = {}
+for step in steps:
+    sid = step['id']
+    step_map[sid] = step
+    agent_ref = step.get('agent_ref')
+    if agent_ref and agent_ref not in agent_ids:
+        print(f"error: step '{sid}' references undeclared agent_ref '{agent_ref}'", file=sys.stderr)
+        sys.exit(1)
+
+# Build dependency graph.
+edges = defaultdict(list)
+indeg = {sid: 0 for sid in step_map.keys()}
+for step in steps:
+    sid = step['id']
+    for dep in step.get('depends_on') or []:
+        if dep not in step_map:
+            print(f"error: step '{sid}' depends_on '{dep}' which is not declared", file=sys.stderr)
+            sys.exit(1)
+        edges[dep].append(sid)
+        indeg[sid] += 1
+
+# Kahn's algorithm for topo sort.
+queue = deque([sid for sid, deg in indeg.items() if deg == 0])
+order = []
+while queue:
+    sid = queue.popleft()
+    order.append(sid)
+    for succ in edges[sid]:
+        indeg[succ] -= 1
+        if indeg[succ] == 0:
+            queue.append(succ)
+
+if len(order) != len(step_map):
+    print(f"error: workflow '{workflow_name}' has a dependency cycle", file=sys.stderr)
+    sys.exit(1)
+
+# Print execution order.
+print(f"execution order: {' -> '.join(order)}")
+print()
+for sid in order:
+    step = step_map[sid]
+    agent_ref = step.get('agent_ref', '(none)')
+    skill_ref = step.get('skill_ref', '(none)')
+    on_failure = step.get('on_failure', 'fail')
+    print(f"  {sid}:")
+    print(f"    agent_ref: {agent_ref}")
+    print(f"    skill_ref: {skill_ref}")
+    print(f"    on_failure: {on_failure}")
+EOPYTHON
+
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    exit $exit_code
+fi
+
+ok "workflow '$workflow_name' DAG is valid"
+step "stub: printing plan only; no invocation wired yet"

--- a/tests/harness/test_workflow_runner.bats
+++ b/tests/harness/test_workflow_runner.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# tests/harness/test_workflow_runner.bats — smoke tests for oma run-workflow.
+
+setup() {
+    export OMA_REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+    export OMA_QUIET=1
+    export NO_COLOR=1
+}
+
+@test "run-workflow on agentic-platform platform-bootstrap returns clean DAG" {
+    run bash "$OMA_REPO_ROOT/scripts/oma/run-workflow.sh" agentic-platform platform-bootstrap
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "execution order: preflight -> provision -> verify" ]]
+    [[ "$output" =~ "agent_ref: agentic-platform" ]]
+    [[ "$output" =~ "skill_ref: agentic-eks-bootstrap" ]]
+}
+
+@test "run-workflow with missing workflow name exits 1" {
+    run bash "$OMA_REPO_ROOT/scripts/oma/run-workflow.sh" agentic-platform nonexistent-workflow
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not found" ]]
+}
+
+@test "run-workflow on plugin with no workflows exits 1 with helpful error" {
+    run bash "$OMA_REPO_ROOT/scripts/oma/run-workflow.sh" agenticops any-workflow
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "declares no workflows" ]]
+}
+
+@test "run-workflow with missing plugin exits 1" {
+    run bash "$OMA_REPO_ROOT/scripts/oma/run-workflow.sh" nonexistent-plugin some-workflow
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not found" ]]
+}
+
+@test "run-workflow prints usage when called with insufficient args" {
+    run bash "$OMA_REPO_ROOT/scripts/oma/run-workflow.sh"
+    [ "$status" -eq 64 ]
+    [[ "$output" =~ "Usage:" ]]
+}


### PR DESCRIPTION
## Summary

Wires the DSL v2 surface added in v0.3b/v0.4 into an actual plugin file and ships a minimal workflow runner stub so the `workflows`, `telemetry`, and `policies` schema shapes are exercised end-to-end.

Part of the v0.3→v0.5 follow-up wave (W2 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Commits

- `feat(harness): populate workflows/telemetry/policies ...` — agentic-platform DSL gains a 3-step workflow, Langfuse OTEL traces/metrics endpoints, and a blocking OPA policy pointer.
- `feat(harness): add oma run-workflow stub ...` — new `scripts/oma/run-workflow.sh` topo-sorts a workflow and prints the execution order. Stub only; no real invocation yet.
- `test(harness): cover run-workflow stub with bats smoke` — 5 bats cases covering happy path + four error branches.

## Test plan

- [x] `oma compile --all` → 5 plugins compile, byte-diff clean.
- [x] `pytest tests/ --ignore=tests/installer --ignore=tests/profile --ignore=tests/hooks --ignore=tests/doctor -q` → 87 passed.
- [x] `bats tests/harness/test_workflow_runner.bats` → 5/5 OK.
- [x] Manual: `oma run-workflow agentic-platform platform-bootstrap` → `execution order: preflight -> provision -> verify`.

## Files changed

- `plugins/agentic-platform/agentic-platform.oma.yaml` — workflows/telemetry/policies populated.
- `scripts/oma/run-workflow.sh` (new) — DAG runner stub, +149 lines.
- `bin/oma` — usage block adds `run-workflow` entry.
- `tests/harness/test_workflow_runner.bats` (new).