### PR TITLE
test(installer)+ci(pages): enterprise smoke bats + upload-pages-artifact v4

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -71,7 +71,7 @@ jobs:
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
           github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 

--- a/tests/installer/test_enterprise_smoke.bats
+++ b/tests/installer/test_enterprise_smoke.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# tests/installer/test_enterprise_smoke.bats
+# Smoke tests for OMA enterprise flags. Exercises `oma doctor --enterprise`,
+# `oma compile --strict-enterprise`, and `oma validate` in a clean checkout.
+# These probes catch breakage in the entity compiler, strict-mode gates, or
+# OPA policy loading before they reach production.
+
+setup() {
+    OMA_REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export OMA_REPO_ROOT
+    export NO_COLOR=1
+    export OMA_QUIET=1
+}
+
+teardown() {
+    # no temp files to clean up; all commands run in-place
+    true
+}
+
+@test "oma doctor --enterprise exits 0 and reports 8 probes OK" {
+    if ! command -v python3 >/dev/null; then
+        skip "python3 not available"
+    fi
+    run bash "$OMA_REPO_ROOT/bin/oma" doctor --enterprise
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"8 probes OK"* ]] || {
+        echo "expected '8 probes OK' in output:"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "oma compile --strict-enterprise exits 0 on clean repo" {
+    if ! command -v python3 >/dev/null; then
+        skip "python3 not available"
+    fi
+    run bash "$OMA_REPO_ROOT/bin/oma" compile --strict-enterprise
+    [ "$status" -eq 0 ]
+}
+
+@test "oma validate accepts a .mcp.json path gracefully" {
+    if ! command -v python3 >/dev/null; then
+        skip "python3 not available"
+    fi
+    # .mcp.json is not an entity YAML, so validate should handle it without
+    # crashing. We check exit 0 (graceful fallback), not exact message.
+    run bash "$OMA_REPO_ROOT/bin/oma" validate \
+        "$OMA_REPO_ROOT/plugins/agentic-platform/.mcp.json"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Two small, unrelated fixes bundled because each is too thin for its own review cycle:

1. **Installer smoke** — new `tests/installer/test_enterprise_smoke.bats` exercises `oma doctor --enterprise`, `oma compile --strict-enterprise`, and `oma validate` from a clean checkout. CI previously had no guard against regressions in these enterprise flags.
2. **Pages action bump** — `actions/upload-pages-artifact@v3` is two majors behind; v4 is the current documented pin.

Part of the v0.3→v0.5 follow-up wave (W5 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Commits

- `test(installer): enterprise smoke bats ...`
- `ci(docs): bump actions/upload-pages-artifact v3 -> v4`

## Test plan

- [x] `pytest tests/ --ignore=tests/installer --ignore=tests/profile --ignore=tests/hooks --ignore=tests/doctor -q` → 87 passed.
- [x] `bats tests/installer/test_enterprise_smoke.bats` → **3/3 OK** locally.
- [x] `oma doctor --enterprise` on this worktree → 8 probes OK.

## Files changed

- `tests/installer/test_enterprise_smoke.bats` (new)
- `.github/workflows/docs-build.yml` (one-line action pin bump)