### PR TITLE
docs: public contributing guide mirroring CLAUDE.md top-level rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,119 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to this project. Whether it is
+a bug report, new feature, correction, or additional documentation, we
+value feedback and contributions from the community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+Please read this document before submitting any issue or pull request.
 
+## Working agreement
 
-## Reporting Bugs/Feature Requests
+Four rules govern every change that lands on `main`. They override any
+conflicting local convention and apply in both manual and automated
+execution modes.
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+1. **English-only artifacts.** Every committed byte must be in English —
+   source code, comments, docstrings, commit messages, PR titles, PR
+   bodies, release notes, and `CHANGELOG.md` entries. Chat with reviewers
+   may happen in any language; files and git objects may not.
+2. **No AI attribution in git.** Do not add `Co-Authored-By: Claude`,
+   `🤖 Generated with Claude Code`, or any equivalent AI attribution to
+   commits, tags, or PR bodies. Git trailers list only human authors. If
+   a commit template injects such lines, strip them before committing.
+3. **`CLAUDE.md` stays local.** `CLAUDE.md` files (project root or
+   plugin-level) are agent-specific configuration and must remain in
+   `.gitignore`. Never `git add` them, and never revert the ignore rule.
+4. **Commit per unit of work.** Every distinct task gets its own commit.
+   Do not batch unrelated changes into a single commit, even when they
+   share a feature branch. A unit of work is the smallest change that
+   leaves the repository in a reviewable, reversible state: one
+   subsystem fix, one schema extension, one doc update, one CI patch.
+   Before `git commit`, inspect `git status` and `git diff --stat` and
+   confirm every staged path belongs to the same logical task. If they
+   do not, split with `git add -p` or by staging individual files. This
+   rule applies under autonomous and long-running execution modes as
+   well — finish a unit, commit, then start the next unit. Do not defer
+   commits "until the whole plan is done."
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+See [`docs/docs/contributing.md`](./docs/docs/contributing.md) for the
+long-form rationale, branch naming conventions, and worked examples.
 
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
+## Branch naming and commit messages
 
+Use a prefix that matches the dominant change type: `feat/`, `fix/`,
+`chore/`, `test/`, `docs/`, `refactor/`, or `ci/`. Commit messages use
+imperative English ("add X", "fix Y", not "added"/"fixes"). The body
+explains *why*, not what — the diff already shows what changed.
 
-## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+## Reporting bugs and feature requests
 
-1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+We welcome you to use the GitHub issue tracker to report bugs or suggest
+features.
 
-To send us a pull request, please:
+When filing an issue, please check existing open and recently closed
+issues to make sure someone else has not already reported it. Include as
+much information as you can:
+
+* A reproducible test case or series of steps.
+* The version of our code being used.
+* Any modifications you made relevant to the bug.
+* Anything unusual about your environment or deployment.
+
+## Contributing via pull requests
+
+Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the `main` branch.
+2. You checked existing open and recently merged pull requests to make
+   sure someone else has not already addressed the problem.
+3. You opened an issue to discuss any significant work — we would hate
+   for your time to be wasted.
+
+To send us a pull request:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+2. Create a feature branch using one of the prefixes listed above.
+3. Modify the source; please focus on the specific change you are
+   contributing. If you also reformat all the code, it will be hard for
+   us to focus on your change.
+4. Ensure local tests pass (`pytest tests/` for the foundation suite,
+   `bats tests/installer tests/profile tests/hooks tests/doctor` for
+   shell tests).
+5. Commit to your fork using clear imperative English commit messages.
+   One commit per unit of work.
+6. Send us a pull request, answering any default questions in the pull
+   request interface.
+7. Pay attention to any automated CI failures reported in the pull
+   request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub documents the mechanics of
+[forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at existing issues is a great way to find something to work on.
+This project uses the default GitHub issue labels
+(enhancement/bug/duplicate/help wanted/invalid/question/wontfix); the
+`help wanted` label is a good starting point.
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
 
+This project has adopted the
+[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the
+[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or
+contact opensource-codeofconduct@amazon.com with any additional
+questions or comments.
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that
+you notify AWS/Amazon Security via our
+[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+Please do **not** create a public GitHub issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for this project's licensing. We will
+ask you to confirm the licensing of your contribution.

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,0 +1,226 @@
+---
+sidebar_position: 55
+title: Contributing
+---
+
+# Contributing guide
+
+This project lives under `aws-samples/` and welcomes external
+contributions. The [repo root
+`CONTRIBUTING.md`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/CONTRIBUTING.md)
+covers the legal and PR-process boilerplate. This page adds the
+engineering-workflow rules that our CI and review process assume.
+
+## The four working-agreement rules
+
+These four rules are non-negotiable. Every pull request is reviewed
+against them before any technical merit discussion begins.
+
+### 1. English-only artifacts
+
+Every byte committed to this repository must be English: source code,
+comments, docstrings, commit messages, pull request titles and bodies,
+release notes, and `CHANGELOG.md` entries. Chat between reviewers and
+contributors may happen in any language, but files and git objects may
+not.
+
+**Why.** Reviewers and downstream automation (link checkers, release
+note extractors, Dependabot) all assume a single language. A Korean
+commit message, even with an English diff, breaks changelog generation
+and makes `git log --grep` unreliable. Keeping the rule absolute avoids
+hand-wringing about which files are "public" and which are not.
+
+**What to check before committing.** Run `git diff --cached` and read
+it top to bottom. If a Korean comment slipped in through an editor's
+autocomplete, translate it before pushing.
+
+### 2. No AI attribution in git
+
+Commits, tags, and PR bodies must not carry `Co-Authored-By: Claude`,
+`🤖 Generated with Claude Code`, or any equivalent AI attribution.
+Trailers list only human authors.
+
+**Why.** Git trailers participate in export control, copyright
+attribution, and customer-facing release notes. AI attribution creates
+legal ambiguity about authorship and licensing, and it clutters
+`git shortlog` output without adding information reviewers can act on.
+
+**What to check before committing.** Some IDE plugins inject trailers
+automatically — set `git config --global commit.template ""` if you
+find phantom trailers in `git log`. Run
+`git log -n 5 --pretty=%b | grep -i claude` after finishing a branch;
+strip anything it finds before opening the PR.
+
+### 3. `CLAUDE.md` stays local
+
+`CLAUDE.md` files — whether at the repo root or inside a plugin — are
+agent-specific configuration. They belong in `.gitignore` and must not
+land in a commit, a PR, or a release artifact.
+
+**Why.** `CLAUDE.md` contains instructions that customise agent
+behaviour for individual contributors and can leak internal workflow
+details. Tracking it would also freeze everyone's agent prompt at
+whatever one contributor committed, which is the opposite of what the
+file is for.
+
+**What to check before committing.** `git check-ignore -v CLAUDE.md`
+should return a rule hit; if it does not, add `CLAUDE.md` to
+`.gitignore` in the same PR. If you see `CLAUDE.md` in
+`git status --short`, do not `git add -A` blindly — use explicit paths.
+
+### 4. Commit per unit of work
+
+Every distinct task gets its own commit. Never batch unrelated changes
+into a single commit, even when they share a feature branch. A unit of
+work is the smallest change that leaves the repository in a reviewable,
+reversible state.
+
+**Why.** Reviews are easier when one commit equals one logical change.
+Reverts are safer: `git revert <sha>` rolls back exactly one concern
+instead of unwinding a shipping release. `git blame` points at the
+commit that changed a specific line for a specific reason, not at a
+grab bag. And when CI fails mid-merge, you can land the commits that
+pass and keep iterating on the one that does not.
+
+**What counts as one unit.**
+
+| Unit | Example |
+|------|---------|
+| One subsystem fix | Bump a single schema's version enum |
+| One schema extension | Add an optional field to `risk.schema.json` |
+| One doc update | Write a new Docusaurus page |
+| One CI patch | Adjust a single workflow's trigger matrix |
+| One refactor | Lift inline strings to module-level constants |
+| One test suite | Add pytest coverage for a newly refactored function |
+
+When a branch contains work across several units, make several
+commits. Do **not** wait until the end of the branch to stage
+everything.
+
+**What to check before committing.** Run `git status --short` and
+`git diff --cached --stat`. If the staged paths span more than one
+unit, split them:
+
+- Use `git add -p` to stage hunks interactively.
+- Use explicit paths (`git add path/to/one/file`) instead of
+  `git add -A` or `git add .`.
+- If you have already committed a batch, `git reset --soft HEAD~1`
+  unstages the mistake without losing the changes so you can split
+  cleanly.
+
+**Rule holds under autonomous modes.** The `boulder never stops`
+hook, long-running agent loops, and multi-PR workflows all still
+honour the rule. Finish a unit, commit it, then start the next one.
+Never defer "until the whole plan is done."
+
+## Branch naming
+
+Use a prefix that matches the dominant change type:
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat/` | User-visible new capability |
+| `fix/` | Bug fix (functional or build) |
+| `chore/` | Maintenance or dependency hygiene |
+| `test/` | Test-only changes |
+| `docs/` | Documentation-only changes |
+| `refactor/` | Internal change, no user-visible behaviour difference |
+| `ci/` | `.github/workflows` changes |
+
+Examples from recent history: `feat/enterprise-ontology-harness-v0.3-v0.5`,
+`fix/security-uuid-14`, `feat/auto-release-page`.
+
+## Commit message style
+
+Use imperative English verbs:
+
+- `feat(audit): migrate component-design writer to …` — good
+- `feat(audit): migrated component-design writer …` — past tense, bad
+- `feat(audit): migration of component-design writer …` — nominalised, bad
+
+Scope is optional but recommended for the larger codebases
+(`feat(compile):`, `test(ontology):`, `ci(docs):`). The body should
+explain **why**, not just what — the diff already shows what changed.
+
+## Commit splitting in practice
+
+Three recent examples from `main` history illustrate the rule in
+action.
+
+### Example 1: v0.3 → v0.5 enterprise rollout
+
+Landed as two commits inside one PR (`feat/enterprise-ontology-harness-v0.3-v0.5`):
+
+- `a4cb99a` — v0.3 foundation (ontology + DSL v2 backbone).
+- `9aafc5a` — v0.4 + v0.5 rollout (SLSA, OTEL, OPA, plugin migration,
+  enterprise doctor).
+
+The two commits could have been one "enterprise rollout" commit. They
+were split because v0.3 is low-risk and release-cuttable on its own;
+v0.4/v0.5 build on it but would survive a revert of only the
+later commit. Reviewers can read the foundation separately from the
+enforcement layer.
+
+### Example 2: CI workflow repair vs unused-imports cleanup
+
+In the same PR that landed the rollout, review feedback surfaced two
+follow-up issues. They shipped as two separate commits:
+
+- `b8c4f84` — fix CI workflow script paths. Unrelated pre-existing bug.
+- `4c66e7f` — drop unused imports flagged by the code-quality bot.
+  Purely cosmetic.
+
+Batching them would have forced a revert of the clean-up to roll back
+the CI fix. Splitting kept each concern reversible.
+
+### Example 3: uuid transitive dependency override
+
+PR #4 shipped as a single commit (`eb7388d`):
+
+- `fix(deps): override transitive uuid to 14.0.0 (GHSA-w5hq-g745-h8pq)`
+
+The diff touches only `docs/package.json` and the regenerated
+`docs/package-lock.json`, and both files exist to serve the same unit
+of work: the security advisory fix. One concern, one commit.
+
+## Running the test suite
+
+```bash
+# Python foundation suite (ontology + audit + harness + compile)
+python -m pip install -e '.[dev]'
+python -m pytest tests/ \
+    --ignore=tests/installer \
+    --ignore=tests/profile \
+    --ignore=tests/hooks \
+    --ignore=tests/doctor \
+    -q
+
+# Shell tests (bats). Install via brew / apt first.
+bats tests/installer
+bats tests/profile
+bats tests/hooks
+bats tests/doctor
+
+# Verify the docs site still builds.
+cd docs
+npm ci
+npm run build
+```
+
+## Rebuilding after schema or DSL changes
+
+Any change to `schemas/**/*.schema.json`, `plugins/*/*.oma.yaml`, or
+`tools/oma_compile/` should be followed by:
+
+```bash
+oma compile --all            # regenerate .mcp.json and kiro-agents/*.agent.json
+oma doctor --enterprise      # run the 8 enterprise-readiness probes
+```
+
+These two commands are the integration test for cross-file coherence.
+If they fail in a PR, do not merge.
+
+## Questions
+
+Open a GitHub issue with the `question` label. The maintainers rotate
+through unanswered issues weekly.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'support-policy',
         'telemetry',
+        'contributing',
         'releases-pipeline',
       ],
     },


### PR DESCRIPTION
## Summary

The four working-agreement rules (English-only artifacts, no AI attribution in git, CLAUDE.md stays local, commit per unit of work) previously lived only inside gitignored CLAUDE.md files. This PR surfaces them into public documentation: a richer `CONTRIBUTING.md` at the repo root and a dedicated `docs/docs/contributing.md` under the Docusaurus Governance sidebar.

Part of the v0.3→v0.5 follow-up wave (W6 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Commits

- `docs: expand CONTRIBUTING.md ...` — adds Working agreement, branch naming, and commit-message style sections; links to the detailed docs page.
- `docs: public contributing guide ...` — new docs/docs/contributing.md + sidebar entry.

## Test plan

- [x] `cd docs && npm run build` — ko + en locales build cleanly.
- [x] `build/docs/contributing.html` and `build/en/docs/contributing.html` are generated.
- [x] Sidebar Governance category shows the new Contributing entry.

## Files changed

- `CONTRIBUTING.md`
- `docs/docs/contributing.md` (new)
- `docs/sidebars.ts`