### PR TITLE
ci(release): explicitly trigger docs-build after gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # needed by the 'Trigger docs-build' step below to run another workflow
 
 jobs:
   test:
@@ -197,3 +198,16 @@ jobs:
               $is_prerelease \
               "dist/oh-my-aidlcops-${{ steps.ver.outputs.tag }}.tar.gz" \
               "dist/oh-my-aidlcops-${{ steps.ver.outputs.tag }}.tar.gz.sha256"
+
+      - name: Trigger docs-build so /releases refreshes
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Belt-and-suspenders: docs-build.yml already subscribes to
+          # `release: published`, but GitHub sometimes fires that event
+          # before Pages picks up the new repo state. Explicitly
+          # dispatching the workflow guarantees the /releases page
+          # regenerates with the new tag even when the event path lags.
+          echo "Dispatching docs-build.yml on main for ${{ steps.ver.outputs.tag }}"
+          gh workflow run docs --repo "$GITHUB_REPOSITORY" --ref main


### PR DESCRIPTION
## Summary

The v0.3.0-preview.1 release surfaced a flaky behaviour: even though `docs-build.yml` subscribes to `release: published`, the event did not fire in a way the workflow acted on, so `/releases` stayed on v0.2 until a human ran `gh workflow run docs` manually.

This PR adds a belt-and-suspenders step at the end of the release job that explicitly dispatches `docs-build` on `main` once `gh release create` succeeds. The existing `release:` subscription stays in place; this just guarantees a second trigger path.

Part of the v0.3 release follow-up wave (N1 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Change detail

- `permissions: actions: write` added so the workflow's `GITHUB_TOKEN` can dispatch other workflows.
- New `Trigger docs-build so /releases refreshes` step (conditional on not being a dry-run) after `Create GitHub Release`. Uses `gh workflow run docs --ref main`.

## Test plan

- [ ] Next real tag push (v0.3.1-preview or v0.4) should show docs-build running twice — once on release event, once on the explicit dispatch — and deploy-pages short-circuits the duplicate.
- [ ] workflow_dispatch with dry_run=true skips the dispatch (same gate as Create GitHub Release).