### PR TITLE
ci: bump actions/checkout v4 -> v5 for Node 24 readiness

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/eval-skills.yml
+++ b/.github/workflows/eval-skills.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
@@ -38,7 +38,7 @@ jobs:
         harness: [claude-code, kiro]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Syntax check install script for ${{ matrix.harness }}
         run: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2

--- a/.github/workflows/oma-foundation.yml
+++ b/.github/workflows/oma-foundation.yml
@@ -36,7 +36,7 @@ jobs:
     name: schemas + compiler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     name: foundation tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -48,7 +48,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Resolve version
         id: ver
         run: |
@@ -74,7 +74,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history so the enrichment step can compute the diff vs the
           # previous tag (git describe + git log).

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

GitHub Actions runners stop defaulting to Node 20 on **2026-09-16**. `actions/checkout@v4` is still pinned to Node 20 and the release-workflow logs already warn about it on every run. v5 is the drop-in replacement with Node 24 support.

Part of the v0.3 release follow-up wave (N6 of `.omao/plans/aidlc-workflow-steady-moler.md`).

## Change

One-line sed bump across six workflows, nine invocations total:

- `.github/workflows/docs-build.yml`
- `.github/workflows/eval-skills.yml` (2 occurrences)
- `.github/workflows/link-check.yml`
- `.github/workflows/oma-foundation.yml`
- `.github/workflows/release.yml` (3 occurrences)
- `.github/workflows/validate-schemas.yml`

No behaviour change. The `with:` blocks (paths, fetch-depth, etc) stay identical.

## Other action pins audited in this PR

| Pin | Status | Action needed |
|---|---|---|
| `actions/checkout@v4` | Node 20 | **bumped to @v5** (this PR) |
| `actions/setup-python@v5` | Node 24 ready | none |
| `actions/setup-node@v5` | Node 24 ready | none |
| `actions/upload-artifact@v4` | Node 24 ready (4.x rolled forward) | none |
| `actions/download-artifact@v4` | Node 24 ready | none |
| `actions/upload-pages-artifact@v4` | Node 24 ready (bumped earlier via PR #9) | none |
| `actions/deploy-pages@v4` | Node 24 ready | none |
| `lycheeverse/lychee-action@SHA` | third-party; tracks upstream | monitor |

## Test plan

- [ ] CI on this branch runs every workflow — all green on the bumped checkout step.
- [ ] Release job's 'Node.js 20 actions are deprecated' warning no longer mentions `actions/checkout@v4` after merge.