### PR TITLE
docs(ontology): cite upstream sources in adr/spec schemas and glossary

### DIFF
--- a/ontology/glossary.md
+++ b/ontology/glossary.md
@@ -112,6 +112,11 @@ MoSCoW priority (`must`/`should`/`may`). Spec supersedes older specs via
 `supersedes[]` and links forward to ADRs via `linked_adrs[]`. Deployments
 reference the spec they satisfy through `Deployment.spec_ref`.
 
+**Source:** the `requirements[]` shape (id / text / MoSCoW priority)
+follows the IEEE Std 830-1998 template and its successor
+ISO/IEC/IEEE 29148-2018. See
+[REFERENCES.md#ieee-830](../REFERENCES.md#ieee-830).
+
 ## ADR
 
 Architecture Decision Record (schema `adr.schema.json`, Draft 2020-12).
@@ -119,6 +124,12 @@ Numbered (`adr-0001-...`), with `context` / `decision` / `consequences`
 sections. An ADR moves from `proposed` -> `accepted` (or `rejected`) and may
 later be `deprecated` or `superseded_by` a later ADR. Deployments reference
 the ADRs they follow via `Deployment.adr_refs[]`.
+
+**Source:** the field set and 5-state status machine trace to Michael
+Nygard's 2011 post "Documenting Architecture Decisions"; the
+`adr-NNNN-<slug>` id format comes from the MADR convention. See
+[REFERENCES.md#nygard-adr](../REFERENCES.md#nygard-adr) and
+[REFERENCES.md#madr](../REFERENCES.md#madr).
 
 ## ApprovalChain
 

--- a/schemas/ontology/adr.schema.json
+++ b/schemas/ontology/adr.schema.json
@@ -2,7 +2,7 @@
   "$id": "https://aws-samples.github.io/sample-oh-my-aidlcops/schemas/ontology/adr.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ADR",
-  "description": "Architecture Decision Record produced during AIDLC Inception or Construction. ADRs constrain Deployments via the adr_refs backlink.",
+  "description": "Architecture Decision Record produced during AIDLC Inception or Construction. ADRs constrain Deployments via the adr_refs backlink. Field set (context / decision / consequences) and the 5-state status machine follow Michael Nygard's 2011 template; the id format follows the MADR (Markdown Any Decision Records) convention. See REFERENCES.md#nygard-adr and REFERENCES.md#madr.",
   "type": "object",
   "additionalProperties": false,
   "required": ["id", "status", "title", "context", "decision"],

--- a/schemas/ontology/spec.schema.json
+++ b/schemas/ontology/spec.schema.json
@@ -2,7 +2,7 @@
   "$id": "https://aws-samples.github.io/sample-oh-my-aidlcops/schemas/ontology/spec.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Spec",
-  "description": "AIDLC Phase 1 (Inception) output capturing requirements, scope, and owner. A Spec feeds ADRs and Deployments downstream via the entityRef enum.",
+  "description": "AIDLC Phase 1 (Inception) output capturing requirements, scope, and owner. A Spec feeds ADRs and Deployments downstream via the entityRef enum. The requirements[] shape (id / text / MoSCoW priority) follows the IEEE 830-1998 template and its successor ISO/IEC/IEEE 29148-2018. See REFERENCES.md#ieee-830.",
   "type": "object",
   "additionalProperties": false,
   "required": ["id", "owner", "status"],


### PR DESCRIPTION
## Summary

OMA's ADR entity shipped with a full Nygard-style field set but no inline citation. Same problem for the Spec entity (IEEE 830). This PR credits the upstream templates in the two schema descriptions and in `ontology/glossary.md`, with REFERENCES.md anchor links.

Part of the v0.3 release follow-up (V4 of `.omao/plans/cheerful-humming-stallman.md`).

## Changes

**adr.schema.json** — description trailing sentences:
- Field set + status machine → Michael Nygard (2011)
- id format → MADR
- Anchors: `REFERENCES.md#nygard-adr`, `#madr`

**spec.schema.json** — description trailing sentence:
- requirements[] shape → IEEE Std 830-1998 + ISO/IEC/IEEE 29148-2018
- Anchor: `REFERENCES.md#ieee-830`

**ontology/glossary.md** — ADR and Spec entries each gain a **Source:** paragraph that repeats the REFERENCES.md anchor links.

## Test plan

- [x] `pytest tests/ontology/test_spec_adr.py tests/ontology/test_schemas.py -q` — all tests pass; schemas still parse as valid JSON Schema.
- [x] `python -c 'import json; json.load(open(...))'` confirms both schema files are valid JSON after the description edit.

## Files changed

- `schemas/ontology/adr.schema.json` — description only.
- `schemas/ontology/spec.schema.json` — description only.
- `ontology/glossary.md` — +10 lines (two Source: paragraphs).