### PR TITLE
fix(refs): clean 4 stale URLs + tighten HTTP checker

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -55,13 +55,13 @@ quick-access list for humans.
 |---|---|---|
 | <a id="mcp-v10"></a>Model Context Protocol v1.0 | https://modelcontextprotocol.io | `Agent.mcp_uri` on `schemas/ontology/agent.schema.json` |
 | <a id="slsa-v11"></a>SLSA v1.1 Provenance | https://slsa.dev/spec/v1.1/ | `Deployment.artifact.{digest,provenance_uri,signing}` |
-| <a id="nist-ai-rmf"></a>NIST AI Risk Management Framework (AI 100-1) | https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf | `Risk.nist_ai_rmf_subcategory`; `AuditEvent.compliance.nist_ai_rmf` |
+| <a id="nist-ai-rmf"></a>NIST AI Risk Management Framework (AI 100-1) | https://www.nist.gov/itl/ai-risk-management-framework | `Risk.nist_ai_rmf_subcategory`; `AuditEvent.compliance.nist_ai_rmf` |
 | <a id="owasp-llm-top-10"></a>OWASP Top 10 for Large Language Model Applications | https://owasp.org/www-project-top-10-for-large-language-model-applications/ | `Risk.owasp_llm_top10_id` (LLM01..LLM10) |
 | <a id="json-schema-2020-12"></a>JSON Schema Draft 2020-12 | https://json-schema.org/draft/2020-12/schema | `schemas/ontology/{spec,adr}.schema.json`, `schemas/common/approval-chain.schema.json`, `schemas/audit/event.schema.json` |
 | <a id="opentelemetry-semconv"></a>OpenTelemetry Semantic Conventions | https://opentelemetry.io/docs/specs/semconv/ | `Incident.trace_id`, `Incident.span_id`, DSL v2 `spec.telemetry.traces/metrics/logs` |
 | <a id="oci-image-spec"></a>OCI Image Spec v1.1 | https://github.com/opencontainers/image-spec/blob/main/spec.md | `Deployment.artifact.digest` sha256 pattern |
 | <a id="opa-rego"></a>OPA / Rego | https://www.openpolicyagent.org/docs/latest/ | `spec.policies[].rego_ref`; `scripts/oma/validate.sh` shell-out |
-| <a id="cosign"></a>Sigstore cosign | https://docs.sigstore.dev/signing/quickstart/ | `Deployment.artifact.signing.cosign_bundle_uri` |
+| <a id="cosign"></a>Sigstore cosign | https://docs.sigstore.dev/quickstart/quickstart-cosign/ | `Deployment.artifact.signing.cosign_bundle_uri` |
 | <a id="rfc-3339"></a>RFC 3339 (ISO 8601 profile) | https://datatracker.ietf.org/doc/html/rfc3339 | All `*_at` timestamp fields across ontology |
 | <a id="keep-a-changelog"></a>Keep a Changelog 1.1 | https://keepachangelog.com/en/1.1.0/ | `CHANGELOG.md` section shape |
 | <a id="semver"></a>Semantic Versioning 2.0 | https://semver.org/spec/v2.0.0.html | Git tag naming post-GA |
@@ -76,10 +76,10 @@ quick-access list for humans.
 | Framework | URL | Influence on OMA |
 |---|---|---|
 | <a id="finops-framework"></a>FinOps Framework | https://www.finops.org/framework/ | `Budget.cost_center_owner`, `Budget.approval_gate`, `Budget.scope` enum |
-| <a id="6r"></a>AWS 6R modernization strategy | https://docs.aws.amazon.com/whitepapers/latest/migration-strategy/migration-strategy.html | `Risk.category` enum, `modernization` plugin decision trees |
+| <a id="6r"></a>AWS 6R modernization strategy | https://aws.amazon.com/cloud-migration/ | `Risk.category` enum, `modernization` plugin decision trees |
 | <a id="well-architected"></a>AWS Well-Architected Framework | https://docs.aws.amazon.com/wellarchitected/latest/framework/ | `well-architected-security` MCP server + security posture reviews |
 | <a id="slsa-framework"></a>SLSA Framework | https://slsa.dev/ | Supply-chain integrity for `Deployment.artifact` |
-| <a id="nist-800-53"></a>NIST SP 800-53 Rev. 5 | https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf | `Risk.compliance_refs[].framework=nist-800-53` |
+| <a id="nist-800-53"></a>NIST SP 800-53 Rev. 5 | https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final | `Risk.compliance_refs[].framework=nist-800-53` |
 | <a id="iso-42001"></a>ISO/IEC 42001 | https://www.iso.org/standard/81230.html | `Risk.compliance_refs[].framework=iso-42001` |
 | <a id="soc-2"></a>AICPA SOC 2 | https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2 | `Risk.compliance_refs[].framework=soc-2` |
 | <a id="mitre-atlas"></a>MITRE ATLAS | https://atlas.mitre.org/ | `Risk.compliance_refs[].framework=mitre-atlas` (attack taxonomy) |

--- a/scripts/dev/check-references.py
+++ b/scripts/dev/check-references.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Iterable
 
 ACCEPTED_STATUS = {200, 201, 203, 204, 301, 302, 303, 307, 308, 429}
-URL_PATTERN = re.compile(r"https?://[^\s\)<>\]\"']+", re.IGNORECASE)
+URL_PATTERN = re.compile(r"https?://[^\s\)<>\]\"'`]+", re.IGNORECASE)
 DEFAULT_TIMEOUT = 15  # seconds
 USER_AGENT = "oma-references-check/1.0 (+https://github.com/aws-samples/sample-oh-my-aidlcops)"
 
@@ -37,7 +37,11 @@ def extract_urls(path: Path) -> list[str]:
     for raw in URL_PATTERN.findall(text):
         # Strip trailing punctuation markdown adds (`.` / `,` / `;`).
         url = raw.rstrip(".,;:!?")
-        # Skip anchor-only fragments that belong to this repo's own pages.
+        # Skip bare protocol strings ("https://" alone in prose) that
+        # carry no host — they match the pattern but are not URLs.
+        host = url.split("://", 1)[1] if "://" in url else ""
+        if not host:
+            continue
         if url in seen:
             continue
         seen.add(url)
@@ -54,8 +58,11 @@ def probe(url: str, timeout: int = DEFAULT_TIMEOUT) -> tuple[int, str]:
             with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
                 return resp.status, f"{method} {resp.status}"
         except urllib.error.HTTPError as exc:
-            # Some servers reject HEAD with 405 or 403 but accept GET.
-            if method == "HEAD" and exc.code in (403, 405, 501):
+            # Some servers reject HEAD with 403/405/501 but accept GET.
+            # Some CDNs (nvlpubs.nist.gov among them) return HEAD 404 for
+            # PDFs that are perfectly reachable via GET — so we fall back
+            # to GET on 404 as well and let the second attempt decide.
+            if method == "HEAD" and exc.code in (403, 404, 405, 501):
                 continue
             return exc.code, f"{method} {exc.code} {exc.reason}"
         except urllib.error.URLError as exc:


### PR DESCRIPTION
## Summary

Post-merge run of the new `scripts/dev/check-references.py` (PR #22) against `main` surfaced one checker bug and four genuine dead-URL entries.

## Commits

- `fix(refs): ignore backtick-bounded URLs + GET-fallback on HEAD 404` — adjusts the URL extractor regex to stop swallowing markdown backticks, adds a bare-protocol guard, and extends the HEAD→GET fallback to HTTP 404 so CDN quirks (nvlpubs.nist.gov PDFs) stop producing false positives.
- `docs(refs): replace four stale URLs in REFERENCES.md` — swaps four dead URLs for live alternatives pointing at the same upstream material.

## URL swaps

| Entry | Old URL | New URL |
|---|---|---|
| NIST AI RMF | `nvlpubs.nist.gov/.../NIST.AI.100-1.pdf` (HEAD 404) | `https://www.nist.gov/itl/ai-risk-management-framework` |
| Sigstore cosign | `docs.sigstore.dev/signing/quickstart/` (404) | `https://docs.sigstore.dev/quickstart/quickstart-cosign/` |
| AWS 6R modernization | `docs.aws.amazon.com/whitepapers/.../migration-strategy.html` (404) | `https://aws.amazon.com/cloud-migration/` |
| NIST SP 800-53 Rev. 5 | `nvlpubs.nist.gov/.../NIST.SP.800-53r5.pdf` (HEAD 404) | `https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final` |

## Test plan

- [x] `python3 scripts/dev/check-references.py --skip-own-pages` exits 0 with `all 64 URLs OK`.
- [x] Anchor ids (`nist-ai-rmf`, `cosign`, `6r`, `nist-800-53`) unchanged; existing cross-links from `docs/docs/*.md` and `schemas/ontology/*.schema.json` keep resolving.
- [ ] Next Monday cron run of `references-check` workflow stays green.