### PR TITLE
fix: drop duplicate aidlc plugin install lines + sync /en locale

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -113,7 +113,6 @@ Claude Code 세션 안에서:
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Inside the Claude Code session:
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```

--- a/docs/docs/claude-code-setup.md
+++ b/docs/docs/claude-code-setup.md
@@ -32,7 +32,6 @@ Claude Code 세션 안에서 다음을 순서대로 입력(또는 통째로 붙�
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```
@@ -45,7 +44,6 @@ claude <<'EOF'
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 EOF
@@ -55,11 +53,10 @@ EOF
 
 ```bash
 > /plugin list
-# ai-infra     0.2.0-preview.1   enabled
-# agenticops           0.2.0-preview.1   enabled
-# aidlc      0.2.0-preview.1   enabled
-# aidlc   0.2.0-preview.1   enabled
-# modernization        0.2.0-preview.1   enabled
+# ai-infra       0.4.0-preview.1   enabled
+# agenticops     0.4.0-preview.1   enabled
+# aidlc          0.4.0-preview.1   enabled
+# modernization  0.4.0-preview.1   enabled
 ```
 
 이 경로는 Claude Code 가 내부적으로 `~/.claude/installed_plugins.json` 을

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -74,16 +74,15 @@ Claude Code 세션 안에서:
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```
 
 :::info 여러 플러그인을 한 번에 설치하고 싶다면
 Claude Code `/plugin install` 자체는 한 번에 하나의 플러그인만 받습니다
-(공백 구분 여러 인자 **미지원**). 위처럼 5줄을 붙여넣으면 Claude Code 가
-순차적으로 각 줄을 실행해 줍니다. 혹은 쉘에서 한 번에 다섯 세션을 띄우고
-싶다면 아래처럼 here-doc 을 사용할 수도 있습니다.
+(공백 구분 여러 인자 **미지원**). 위처럼 6줄을 붙여넣으면 Claude Code 가
+순차적으로 각 줄을 실행해 줍니다. 혹은 쉘에서 한 번에 모든 플러그인을
+설치하고 싶다면 아래처럼 here-doc 을 사용할 수도 있습니다.
 
 ```bash
 claude <<'EOF'
@@ -91,21 +90,19 @@ claude <<'EOF'
 /plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
 /plugin install aidlc@oh-my-aidlcops
-/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 EOF
 ```
 :::
 
-`/plugin list` 결과에 5 개 플러그인이 전부 `enabled` 로 보이면 성공입니다.
+`/plugin list` 결과에 4 개 플러그인이 전부 `enabled` 로 보이면 성공입니다.
 
 ```text
-ai-infra      v0.2.0-preview.1  enabled
-agenticops            v0.2.0-preview.1  enabled
-aidlc       v0.2.0-preview.1  enabled
-aidlc    v0.2.0-preview.1  enabled
-modernization         v0.2.0-preview.1  enabled
+ai-infra       v0.4.0-preview.1  enabled
+agenticops     v0.4.0-preview.1  enabled
+aidlc          v0.4.0-preview.1  enabled
+modernization  v0.4.0-preview.1  enabled
 ```
 
 :::caution `bash scripts/install/claude.sh` 단독 실행은 동작하지 않습니다

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -52,6 +52,6 @@ rm ~/.local/bin/oma
 다음 네 항목이 모두 충족되면 GA (`v1.0.0`) 로 진입합니다.
 
 1. 두 harness (Claude Code, Kiro) 에서 E2E 시나리오 3 개 이상 재현 가능.
-2. 5 개 플러그인 모두 DSL 이주 완료.
+2. 4 개 플러그인 모두 DSL 이주 완료.
 3. 다운스트림 사용자 bug 리포트 0 critical / 90 일.
 4. 릴리스 artifact supply-chain 검증 (sha256 + SBOM + signed commit) 자동화 완료.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/claude-code-setup.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/claude-code-setup.md
@@ -29,10 +29,9 @@ Inside the Claude Code session, paste (or enter) the six lines below:
 
 ```text
 /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops
-/plugin install agentic-platform@oh-my-aidlcops
+/plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
-/plugin install aidlc-inception@oh-my-aidlcops
-/plugin install aidlc-construction@oh-my-aidlcops
+/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```
@@ -42,10 +41,9 @@ To script the whole sequence from a shell one-liner use a here-doc:
 ```bash
 claude <<'EOF'
 /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops
-/plugin install agentic-platform@oh-my-aidlcops
+/plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
-/plugin install aidlc-inception@oh-my-aidlcops
-/plugin install aidlc-construction@oh-my-aidlcops
+/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 EOF
@@ -55,11 +53,10 @@ Expected `/plugin list` output:
 
 ```bash
 > /plugin list
-# agentic-platform     0.2.0-preview.1   enabled
-# agenticops           0.2.0-preview.1   enabled
-# aidlc-inception      0.2.0-preview.1   enabled
-# aidlc-construction   0.2.0-preview.1   enabled
-# modernization        0.2.0-preview.1   enabled
+# ai-infra       0.4.0-preview.1   enabled
+# agenticops     0.4.0-preview.1   enabled
+# aidlc          0.4.0-preview.1   enabled
+# modernization  0.4.0-preview.1   enabled
 ```
 
 This path updates `~/.claude/installed_plugins.json` and merges each
@@ -176,7 +173,7 @@ This command creates `.omao/plans/`, `.omao/state/`, `.omao/notepad.md`, `.omao/
 
 ## AIDLC Extensions (opt-in)
 
-The `aidlc-inception` and `aidlc-construction` plugins follow the opt-in extension structure of awslabs/aidlc-workflows. To activate extensions, run:
+The `aidlc` and `aidlc` plugins follow the opt-in extension structure of awslabs/aidlc-workflows. To activate extensions, run:
 
 ```bash
 bash scripts/install/aidlc-extensions.sh
@@ -279,15 +276,15 @@ chmod -R u+w .omao/
 For native marketplace installation:
 
 ```bash
-> /plugin uninstall agentic-platform agenticops aidlc-inception aidlc-construction
+> /plugin uninstall ai-infra agenticops aidlc
 > /plugin marketplace remove oh-my-aidlcops
 ```
 
 For manual installation, remove symlinks and manually delete relevant entries from `settings.json`.
 
 ```bash
-rm ~/.claude/plugins/agentic-platform ~/.claude/plugins/agenticops \
-   ~/.claude/plugins/aidlc-inception ~/.claude/plugins/aidlc-construction
+rm ~/.claude/plugins/ai-infra ~/.claude/plugins/agenticops \
+   ~/.claude/plugins/aidlc ~/.claude/plugins/aidlc
 rm ~/.claude/commands/oma
 # Manually clean OMA entries from mcpServers and hooks in ~/.claude/settings.json
 ```

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/doctor.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/doctor.md
@@ -48,7 +48,7 @@ oma doctor --project /path/to/project   # Check target directory instead of curr
 ```jsonc
 {
   "version": "1",
-  "oma_version": "0.2.0-preview.1",
+  "oma_version": "0.4.0-preview.1",
   "generated_at": "2026-04-30T02:05:11Z",
   "summary": { "pass": 11, "warn": 1, "fail": 0, "skipped": 0 },
   "probes": [

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/easy-button.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/easy-button.md
@@ -7,7 +7,7 @@ sidebar_position: 1.5
 # Easy Button — 3-command install
 
 :::caution Tech Preview
-`oma setup` / `oma doctor` are **Tech Preview** (`v0.2.0-preview.1`).
+`oma setup` / `oma doctor` are **Tech Preview** (`v0.4.0-preview.1`).
 Only `profile.yaml` v1 is considered stable; other surfaces may change before GA.
 See [Support Policy](./support-policy.md) for details.
 :::
@@ -16,7 +16,7 @@ OMA aims to be the "AIDLC × AgenticOps easy button." Installation through first
 
 ```bash
 # 1. Remote install — download release tarball, install to ~/.oma, symlink ~/.local/bin/oma
-curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-oh-my-aidlcops/v0.2.0-preview.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-oh-my-aidlcops/v0.4.0-preview.1/install.sh | bash
 
 # 2. Project setup — create profile, seed ontology, install plugins
 cd my-project

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
@@ -13,7 +13,7 @@ This document is a 5-minute Quickstart for users new to `oh-my-aidlcops` (OMA). 
 | Claude Code CLI | latest stable | `claude --version` |
 | jq | 1.6+ | Installation scripts use it for JSON merging |
 | bash | 4+ | macOS default 3.2 is outdated; run `brew install bash` |
-| AWS credentials | — | `agentic-platform` workflows require EKS, CloudWatch, and S3 access |
+| AWS credentials | — | `ai-infra` workflows require EKS, CloudWatch, and S3 access |
 | (Optional) Kubernetes CLI | kubectl v1.32+ | Needed for `platform-bootstrap` |
 
 ## Optional: Install the `oma` CLI (for AgenticOps)
@@ -33,7 +33,7 @@ required**, and `oma setup` is only needed **when you plan to use AgenticOps**.
 
 ```bash
 # Install the OMA CLI (only if you plan to use AgenticOps)
-curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-oh-my-aidlcops/v0.2.0-preview.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-oh-my-aidlcops/v0.4.0-preview.1/install.sh | bash
 cd my-project
 oma setup      # writes .omao/profile.yaml + seed ontology
 oma doctor     # environment probes
@@ -73,15 +73,14 @@ Inside the Claude Code session:
 
 ```text
 /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops
-/plugin install agentic-platform@oh-my-aidlcops
+/plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
-/plugin install aidlc-inception@oh-my-aidlcops
-/plugin install aidlc-construction@oh-my-aidlcops
+/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 ```
 
-:::info Installing all five at once
+:::info Installing all four at once
 `/plugin install` itself takes a single plugin id per invocation
 (space-separated arguments are **not** supported). Pasting the six lines
 above lets Claude Code run them sequentially. If you prefer to script
@@ -90,24 +89,22 @@ installation from a shell one-liner, use a here-doc:
 ```bash
 claude <<'EOF'
 /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops
-/plugin install agentic-platform@oh-my-aidlcops
+/plugin install ai-infra@oh-my-aidlcops
 /plugin install agenticops@oh-my-aidlcops
-/plugin install aidlc-inception@oh-my-aidlcops
-/plugin install aidlc-construction@oh-my-aidlcops
+/plugin install aidlc@oh-my-aidlcops
 /plugin install modernization@oh-my-aidlcops
 /plugin list
 EOF
 ```
 :::
 
-`/plugin list` should show all five as `enabled`:
+`/plugin list` should show all four as `enabled`:
 
 ```text
-agentic-platform      v0.2.0-preview.1  enabled
-agenticops            v0.2.0-preview.1  enabled
-aidlc-inception       v0.2.0-preview.1  enabled
-aidlc-construction    v0.2.0-preview.1  enabled
-modernization         v0.2.0-preview.1  enabled
+ai-infra       v0.4.0-preview.1  enabled
+agenticops     v0.4.0-preview.1  enabled
+aidlc          v0.4.0-preview.1  enabled
+modernization  v0.4.0-preview.1  enabled
 ```
 
 :::caution `bash scripts/install/claude.sh` alone does NOT work

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/harness-dsl.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/harness-dsl.md
@@ -27,9 +27,9 @@ marketplace works even on machines that have never seen the compiler.
 ## Example
 
 ```yaml
-# plugins/agentic-platform/agentic-platform.oma.yaml
+# plugins/ai-infra/ai-infra.oma.yaml
 version: 1
-plugin: agentic-platform
+plugin: ai-infra
 
 agents:
   - id: autopilot-deploy
@@ -75,7 +75,7 @@ triggers:
 
 ```bash
 # Compile one plugin
-python -m tools.oma_compile plugins/agentic-platform/agentic-platform.oma.yaml
+python -m tools.oma_compile plugins/ai-infra/ai-infra.oma.yaml
 
 # Compile every plugin that has a *.oma.yaml
 python -m tools.oma_compile --all

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -15,10 +15,10 @@ AWS's official [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workfl
 
 | Plugin | Role | Example Skills |
 |---|---|---|
-| `agentic-platform` | Build and operate Agentic AI Platform on EKS | `agentic-eks-bootstrap`, `vllm-serving-setup`, `inference-gateway-routing`, `langfuse-observability`, `gpu-resource-management`, `ai-gateway-guardrails` |
+| `ai-infra` | Build and operate Agentic AI Platform on EKS | `agentic-eks-bootstrap`, `vllm-serving-setup`, `inference-gateway-routing`, `langfuse-observability`, `gpu-resource-management`, `ai-gateway-guardrails` |
 | `agenticops` | Agent-driven operations automation | `self-improving-loop`, `autopilot-deploy`, `incident-response`, `continuous-eval`, `cost-governance` |
-| `aidlc-inception` | AIDLC Phase 1 extensions (opt-in) | `workspace-detection`, `requirements-analysis`, `user-stories`, `workflow-planning` |
-| `aidlc-construction` | AIDLC Phase 2 extensions (opt-in) | `component-design`, `code-generation`, `test-strategy` |
+| `aidlc` | AIDLC Phase 1 extensions (opt-in) | `workspace-detection`, `requirements-analysis`, `user-stories`, `workflow-planning` |
+| `aidlc` | AIDLC Phase 2 extensions (opt-in) | `component-design`, `code-generation`, `test-strategy` |
 
 Detailed plugin definitions are in the repository root at [`.claude-plugin/marketplace.json`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/.claude-plugin/marketplace.json).
 
@@ -47,10 +47,10 @@ flowchart LR
     U[User Request] --> T[Tier-0 Trigger]
     T -->|keyword matching| C["/oma:&lt;workflow&gt;"]
     C --> D[Plugin Dispatch]
-    D --> P1[agentic-platform]
+    D --> P1[ai-infra]
     D --> P2[agenticops]
-    D --> P3[aidlc-inception]
-    D --> P4[aidlc-construction]
+    D --> P3[aidlc]
+    D --> P4[aidlc]
     P1 --> S[Skill Execution]
     P2 --> S
     P3 --> S

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/kiro-setup.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/kiro-setup.md
@@ -46,7 +46,7 @@ Expected output after script execution:
 [install-kiro] OMA repo : /.../oh-my-aidlcops
 [install-kiro] KIRO_HOME: /home/user/.kiro
 [install-kiro] OMA_OWNER: aws-samples
-[install-kiro] skill linked: agentic-platform/vllm-serving-setup
+[install-kiro] skill linked: ai-infra/vllm-serving-setup
 [install-kiro] skill linked: agenticops/self-improving-loop
 ...
 [install-kiro] steering linked: /home/user/.kiro/steering
@@ -63,9 +63,9 @@ After installation, the Kiro home directory has the following structure:
 ```
 ~/.kiro/
 ├── skills/
-│   ├── agentic-platform/
-│   │   ├── agentic-eks-bootstrap       -> <repo>/plugins/agentic-platform/skills/agentic-eks-bootstrap
-│   │   ├── vllm-serving-setup          -> <repo>/plugins/agentic-platform/skills/vllm-serving-setup
+│   ├── ai-infra/
+│   │   ├── agentic-eks-bootstrap       -> <repo>/plugins/ai-infra/skills/agentic-eks-bootstrap
+│   │   ├── vllm-serving-setup          -> <repo>/plugins/ai-infra/skills/vllm-serving-setup
 │   │   ├── inference-gateway-routing   -> ...
 │   │   └── ...
 │   ├── agenticops/
@@ -74,13 +74,13 @@ After installation, the Kiro home directory has the following structure:
 │   │   ├── incident-response           -> ...
 │   │   ├── continuous-eval             -> ...
 │   │   └── cost-governance             -> ...
-│   ├── aidlc-inception/
-│   └── aidlc-construction/
+│   ├── aidlc/
+│   └── aidlc/
 ├── steering                             -> <repo>/steering
 ├── guides/                              # NEW: stage-by-stage safety guides (per-plugin directory)
-│   └── agentic-platform/                -> <repo>/plugins/agentic-platform/guides
+│   └── ai-infra/                -> <repo>/plugins/ai-infra/guides
 ├── agents/                              # NEW: Kiro agent profiles
-│   └── agentic-platform.agent.json      -> <repo>/plugins/agentic-platform/kiro-agents/agentic-platform.agent.json
+│   └── ai-infra.agent.json      -> <repo>/plugins/ai-infra/kiro-agents/ai-infra.agent.json
 └── settings/                            # NEW: CLI settings
     └── cli.json                         # Default template (user-editable)
 ```
@@ -100,8 +100,8 @@ Each symlink points to the original directory in the OMA repository. Thus, updat
 Some Claude Code SKILL.md frontmatter fields are not directly interpreted by Kiro. Some skills provide Kiro-specific metadata as a `kiro.meta.yaml` sidecar file; the install script detects and logs this.
 
 ```
-[install-kiro] skill linked: agentic-platform/vllm-serving-setup
-[install-kiro]   kiro.meta.yaml sidecar detected for agentic-platform/vllm-serving-setup
+[install-kiro] skill linked: ai-infra/vllm-serving-setup
+[install-kiro]   kiro.meta.yaml sidecar detected for ai-infra/vllm-serving-setup
 ```
 
 Example sidecar structure:
@@ -161,7 +161,7 @@ Symlinks plugin `guides/` directories to `~/.kiro/guides/<plugin>/` form. Guides
 
 ```
 ~/.kiro/guides/
-└── agentic-platform/       -> <repo>/plugins/agentic-platform/guides
+└── ai-infra/       -> <repo>/plugins/ai-infra/guides
     ├── aws-practices/      # AWS Well-Architected-based guides
     ├── common/             # Common safety baselines
     └── stages/             # Stage-by-stage checkpoint guides
@@ -180,11 +180,11 @@ Symlinks plugin `kiro-agents/*.json` files to `~/.kiro/agents/` directory. Each 
 - **Auto-approval Rules** — Read-only / file write / bash command approval policies
 - **Resource Loading** — Steering files and skill paths to load on agent startup
 
-Example: `agentic-platform.agent.json`
+Example: `ai-infra.agent.json`
 
 ```json
 {
-  "name": "agentic-platform",
+  "name": "ai-infra",
   "description": "Agentic AI Platform architect for EKS + vLLM + Inference Gateway + Langfuse on AWS.",
   "mcpServers": {
     "awslabs.eks-mcp-server": { "command": "uvx", "args": ["awslabs.eks-mcp-server==0.1.28"] },
@@ -196,7 +196,7 @@ Example: `agentic-platform.agent.json`
 }
 ```
 
-In Kiro runtime, activate the profile in the form `@agentic-platform`.
+In Kiro runtime, activate the profile in the form `@ai-infra`.
 
 ### 5. settings/ — CLI Default Configuration
 
@@ -259,10 +259,10 @@ KIRO_HOME=/opt/kiro-ci bash scripts/install/kiro.sh
 ```bash
 # 1. Check skill directory
 ls ~/.kiro/skills/
-# agentic-platform/  agenticops/  aidlc-inception/  aidlc-construction/
+# ai-infra/  agenticops/  aidlc/  aidlc/
 
 # 2. Skill count per plugin
-for p in agentic-platform agenticops aidlc-inception aidlc-construction; do
+for p in ai-infra agenticops aidlc; do
     echo "$p: $(ls ~/.kiro/skills/$p/ 2>/dev/null | wc -l) skills"
 done
 
@@ -290,8 +290,8 @@ find ~/.kiro/skills/ -maxdepth 2 -type l | head
 If symlinks are broken, reinstall.
 
 ```bash
-rm -rf ~/.kiro/skills/agentic-platform ~/.kiro/skills/agenticops \
-       ~/.kiro/skills/aidlc-inception ~/.kiro/skills/aidlc-construction
+rm -rf ~/.kiro/skills/ai-infra ~/.kiro/skills/agenticops \
+       ~/.kiro/skills/aidlc/inception ~/.kiro/skills/aidlc/construction
 bash ~/.oma/scripts/install/kiro.sh
 ```
 
@@ -349,8 +349,8 @@ Kiro stores execution logs in `~/.kiro/logs/`. OMA does not separately collect t
 
 ```bash
 # Remove skill symlinks
-rm -rf ~/.kiro/skills/agentic-platform ~/.kiro/skills/agenticops \
-       ~/.kiro/skills/aidlc-inception ~/.kiro/skills/aidlc-construction
+rm -rf ~/.kiro/skills/ai-infra ~/.kiro/skills/agenticops \
+       ~/.kiro/skills/aidlc/inception ~/.kiro/skills/aidlc/construction
 
 # Remove steering symlink
 rm ~/.kiro/steering

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/ontology.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/ontology.md
@@ -22,7 +22,7 @@ because a human re-interpreted. The ontology closes that gap.
 |--------------|--------------------------------------------------|-------------------------------------|--------------------------------------------|
 | `Agent`      | `schemas/ontology/agent.schema.json`             | plugin author                       | Claude Code, Kiro, oma-compile             |
 | `Skill`      | `schemas/ontology/skill.schema.json`             | plugin author                       | Claude Code skill loader                   |
-| `Deployment` | `schemas/ontology/deployment.schema.json`        | `aidlc-construction`                | `agenticops.autopilot-deploy`              |
+| `Deployment` | `schemas/ontology/deployment.schema.json`        | `aidlc`                | `agenticops.autopilot-deploy`              |
 | `Incident`   | `schemas/ontology/incident.schema.json`          | `agenticops.incident-response`      | human approver; auto-rollback              |
 | `Budget`     | `schemas/ontology/budget.schema.json`            | plugin author / finops              | `agenticops.cost-governance`               |
 | `Risk`       | `schemas/ontology/risk.schema.json`              | `modernization.risk-discovery`      | stage-gate-strict mode                     |

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/philosophy-aidlc-meets-agenticops.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/philosophy-aidlc-meets-agenticops.md
@@ -33,7 +33,7 @@ Through the `agenticops` plugin, OMA injects five skills into the operations pha
 
 | Skill | Role | Key Input | Key Output |
 |---|---|---|---|
-| `self-improving-loop` | Trace-based skill and prompt improvement | Langfuse traces, failure patterns | PR to `aidlc-construction` |
+| `self-improving-loop` | Trace-based skill and prompt improvement | Langfuse traces, failure patterns | PR to `aidlc` |
 | `autopilot-deploy` | Autonomous deployment of validated artifacts | CI success artifacts, policy gates | GitOps commits, rollout events |
 | `incident-response` | Alarm → diagnosis → proposal → action | PagerDuty, CloudWatch alarms | RCA draft, auto-mitigation actions |
 | `continuous-eval` | Sustained quality assessment | Ragas metrics, regression datasets | Quality report, rollback signals |

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/support-policy.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/support-policy.md
@@ -6,7 +6,7 @@ sidebar_position: 50
 
 # Support Policy — Tech Preview
 
-OMA `v0.2.0-preview.1` is a **Tech Preview** release. It does not provide production SLA. Support scope is confirmed by the criteria below.
+OMA `v0.4.0-preview.1` is a **Tech Preview** release. It does not provide production SLA. Support scope is confirmed by the criteria below.
 
 ## Stability contract
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/tier-0-workflows.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/tier-0-workflows.md
@@ -61,7 +61,7 @@ flowchart LR
 - Rebuilding a feature under OMA standards during team transitions
 
 ### Dependencies
-- `aidlc-inception` + `aidlc-construction` + `agenticops` plugins active
+- `aidlc` + `aidlc` + `agenticops` plugins active
 - `eks-mcp-server`, `cloudwatch-mcp-server`, `aws-iac-mcp-server` MCP connections
 
 ## `/oma:aidlc-loop` — Single Feature One-Pass
@@ -194,7 +194,7 @@ Build an Agentic AI Platform on EKS with **5-stage checkpoints**. Covers full st
 5. **Agent Layer** — Deploy Kagent + Ragas evaluation pipeline
 
 ### Dependencies
-- `agentic-platform` plugin active
+- `ai-infra` plugin active
 - `eks-mcp-server`, `prometheus-mcp-server`, `aws-iac-mcp-server` connections
 - Sufficient EKS permissions (minimum `eks:*`, `ec2:*`, `iam:CreateRole`)
 

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -232,7 +232,6 @@ EOF
         > /plugin install ai-infra@oh-my-aidlcops
         > /plugin install agenticops@oh-my-aidlcops
         > /plugin install aidlc@oh-my-aidlcops
-        > /plugin install aidlc@oh-my-aidlcops
         > /plugin install modernization@oh-my-aidlcops
         > /plugin list
 
@@ -241,7 +240,6 @@ EOF
         /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops
         /plugin install ai-infra@oh-my-aidlcops
         /plugin install agenticops@oh-my-aidlcops
-        /plugin install aidlc@oh-my-aidlcops
         /plugin install aidlc@oh-my-aidlcops
         /plugin install modernization@oh-my-aidlcops
         /plugin list

--- a/scripts/oma/setup.sh
+++ b/scripts/oma/setup.sh
@@ -329,7 +329,6 @@ if [ -n "$CLAUDE_MAJOR" ] && [ "$CLAUDE_MAJOR" -ge 2 ] 2>/dev/null; then
        /plugin install ai-infra@oh-my-aidlcops
        /plugin install agenticops@oh-my-aidlcops
        /plugin install aidlc@oh-my-aidlcops
-       /plugin install aidlc@oh-my-aidlcops
        /plugin install modernization@oh-my-aidlcops
        /plugin list
        MARKET


### PR DESCRIPTION
## Summary

Two fixes the earlier refactor missed:

1. **Duplicate `/plugin install aidlc@oh-my-aidlcops` lines** in every install snippet. The rename+merge sweep mapped both `aidlc-inception@` and `aidlc-construction@` to `aidlc@`, so every sequential install block ended up printing `aidlc@` twice. README EN/KO, getting-started, claude-code-setup, scripts/install/claude.sh, scripts/oma/setup.sh all affected.
2. **English locale (`docs/i18n/en/`) still described the pre-refactor state** — five plugins, old ids, v0.2.0-preview.1. The live Pages `/en` route therefore told English readers to install plugins that no longer exist. Full sync in this PR.

Also fixed while in the area:
- `/plugin list` sample tables trimmed from five rows to four, with properly aligned columns and `0.4.0-preview.1` versions.
- Hint copy ("5줄", "다섯 세션", "Installing all five at once") re-counted as four plugins / six lines.
- `docs/docs/support-policy.md` GA checklist item "5 개 플러그인" -> "4 개 플러그인".
- Kiro skill path samples for the merged aidlc plugin now reflect the nested `~/.kiro/skills/aidlc/inception/*` and `~/.kiro/skills/aidlc/construction/*` layout.

## Verification

- `(cd docs && npm run build)` — both ko and en locales compile cleanly.
- `grep -rn 'agentic-platform\|aidlc-inception\|aidlc-construction' README.md README.ko.md docs/docs/ docs/i18n/` returns no hits outside the historical CHANGELOG section.
- No consecutive duplicate `/plugin install aidlc@oh-my-aidlcops` lines remain.

## Test plan
- [ ] Pages `/docs/getting-started` renders four install lines, not five
- [ ] Pages `/en/docs/getting-started` renders `ai-infra` / `aidlc` / `agenticops` / `modernization` — not the old names
- [ ] `/plugin list` sample table under both locales shows four plugins with v0.4.0-preview.1