### PR TITLE
Fix/hook context delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ breaking changes to non-stable surfaces as documented in
 - (next release entries go here)
 
 ### Fixed
+- `hooks/{session-start,user-prompt-submit}.sh` now emit
+  `{hookSpecificOutput: {hookEventName, additionalContext}}` instead
+  of the bare `{additionalContext}` form. Claude Code 2.x ignores
+  the legacy shape silently — the user sees no effect from any hook
+  output (trigger keywords, budget warnings, ontology status block,
+  active-mode reminder, project memory). Confirmed against
+  Anthropic's 2.1.x hook reference. Affected emit sites: session-start
+  jq + python3 + python fallbacks; user-prompt-submit trigger and
+  budget branches. Existing bats assertions migrated to the new jq
+  path `.hookSpecificOutput.additionalContext`.
 - `hooks/{session-start,user-prompt-submit}.sh` now resolve every
   `.omao/...` path against `$CLAUDE_PROJECT_DIR` (with `OMA_PROJECT_DIR`
   and `$PWD` as fallbacks) instead of the bare cwd. Claude Code spawns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,17 @@ breaking changes to non-stable surfaces as documented in
 - (next release entries go here)
 
 ### Fixed
-- (next release entries go here)
+- `hooks/{session-start,user-prompt-submit}.sh` now resolve every
+  `.omao/...` path against `$CLAUDE_PROJECT_DIR` (with `OMA_PROJECT_DIR`
+  and `$PWD` as fallbacks) instead of the bare cwd. Claude Code spawns
+  hooks from whichever directory `claude` was invoked in, so the
+  previous relative-path lookups silently skipped when the cwd
+  diverged from the project root. Affected paths: trigger detection
+  (`.omao/triggers.json`), active-mode reminder
+  (`.omao/state/active-mode`), project-memory loading
+  (`.omao/project-memory.json`), ontology status block
+  (`.omao/ontology/`), and the budget warning
+  (`.omao/ontology/budgets/`).
 
 ## [0.4.0-preview.1] — 2026-05-02
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -104,25 +104,44 @@ Keyword triggers are active. Type keywords like 'autopilot', 'agenticops', 'ince
 
 # Emit JSON output.
 #
+# Claude Code 2.x expects:
+#   { "hookSpecificOutput": { "hookEventName": "SessionStart",
+#                              "additionalContext": "..." } }
+# A bare {additionalContext: "..."} is NOT honored by 2.x — the context
+# silently drops out, and the user sees no effect from the hook.
+#
 # CRITICAL: ADDITIONAL_CONTEXT is built from files on disk
 # (.omao/state/active-mode, .omao/project-memory.json) that may contain double
-# quotes, backslashes, newlines, or control characters. Naive
-# `echo "{\"additionalContext\": \"$VAR\"}"` would break the emitted JSON and,
-# worse, let a crafted state file inject arbitrary keys into the session
-# context. We REQUIRE a real JSON encoder: jq is preferred, Python 3 is an
-# acceptable fallback. We never fall back to shell-string interpolation.
+# quotes, backslashes, newlines, or control characters. Naive shell-string
+# interpolation would break the emitted JSON and let a crafted state file
+# inject arbitrary keys. We REQUIRE a real JSON encoder.
 if command -v jq >/dev/null 2>&1; then
-  jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
+  jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: $ctx
+    }
+  }'
 elif command -v python3 >/dev/null 2>&1; then
   ADDITIONAL_CONTEXT="$ADDITIONAL_CONTEXT" python3 -c '
 import json, os, sys
-sys.stdout.write(json.dumps({"additionalContext": os.environ["ADDITIONAL_CONTEXT"]}))
+sys.stdout.write(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": os.environ["ADDITIONAL_CONTEXT"]
+    }
+}))
 sys.stdout.write("\n")
 '
 elif command -v python >/dev/null 2>&1; then
   ADDITIONAL_CONTEXT="$ADDITIONAL_CONTEXT" python -c '
 import json, os, sys
-sys.stdout.write(json.dumps({"additionalContext": os.environ["ADDITIONAL_CONTEXT"]}))
+sys.stdout.write(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": os.environ["ADDITIONAL_CONTEXT"]
+    }
+}))
 sys.stdout.write("\n")
 '
 else

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -13,11 +13,17 @@ if [[ "${OMA_DISABLE_TRIGGERS:-0}" == "1" ]]; then
   exit 0
 fi
 
+# Resolve the project directory. Claude Code passes CLAUDE_PROJECT_DIR to
+# hooks (the cwd at `claude` startup). For other harnesses or local
+# invocations, fall back to $PWD. Every .omao/ path below MUST go through
+# this so the hook works no matter what cwd Claude spawns it with.
+OMA_PROJ_DIR="${CLAUDE_PROJECT_DIR:-${OMA_PROJECT_DIR:-$PWD}}"
+
 ADDITIONAL_CONTEXT=""
 
 # Check for active Tier-0 mode
-if [[ -f ".omao/state/active-mode" ]]; then
-  ACTIVE_MODE=$(cat ".omao/state/active-mode" 2>/dev/null || echo "")
+if [[ -f "$OMA_PROJ_DIR/.omao/state/active-mode" ]]; then
+  ACTIVE_MODE=$(cat "$OMA_PROJ_DIR/.omao/state/active-mode" 2>/dev/null || echo "")
   if [[ -n "$ACTIVE_MODE" ]]; then
     ADDITIONAL_CONTEXT+="[OMA Session Context]
 
@@ -30,8 +36,8 @@ This mode is currently running. Use /oma:cancel to terminate if needed.
 fi
 
 # Load project memory if exists
-if [[ -f ".omao/project-memory.json" ]]; then
-  PROJECT_MEMORY=$(cat ".omao/project-memory.json" 2>/dev/null || echo "")
+if [[ -f "$OMA_PROJ_DIR/.omao/project-memory.json" ]]; then
+  PROJECT_MEMORY=$(cat "$OMA_PROJ_DIR/.omao/project-memory.json" 2>/dev/null || echo "")
   if [[ -n "$PROJECT_MEMORY" ]]; then
     ADDITIONAL_CONTEXT+="Project Memory:
 $PROJECT_MEMORY
@@ -45,7 +51,7 @@ fi
 # starts with awareness of active budgets, open incidents, and pending
 # deployments. Kill switch: OMA_DISABLE_ONTOLOGY=1.
 if [[ "${OMA_DISABLE_ONTOLOGY:-0}" != "1" ]] && command -v jq >/dev/null 2>&1; then
-  ONTOLOGY_DIR=".omao/ontology"
+  ONTOLOGY_DIR="$OMA_PROJ_DIR/.omao/ontology"
   if [[ -d "$ONTOLOGY_DIR" ]]; then
     ONTOLOGY_BLOCK=""
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -12,12 +12,16 @@ if [[ "${OMA_DISABLE_TRIGGERS:-0}" == "1" ]]; then
   exit 0
 fi
 
-# Locate triggers.json (repo-relative or user project)
+# Resolve the project directory. Claude Code passes CLAUDE_PROJECT_DIR
+# to hooks (the cwd at `claude` startup). For other harnesses or local
+# invocations, fall back to $PWD. Every .omao/ path below MUST go through
+# this so the hook works no matter what cwd Claude spawns it with.
+OMA_PROJ_DIR="${CLAUDE_PROJECT_DIR:-${OMA_PROJECT_DIR:-$PWD}}"
+
+# Locate triggers.json
 TRIGGERS_JSON=""
-if [[ -f ".omao/triggers.json" ]]; then
-  TRIGGERS_JSON=".omao/triggers.json"
-elif [[ -f "./.omao/triggers.json" ]]; then
-  TRIGGERS_JSON="./.omao/triggers.json"
+if [[ -f "$OMA_PROJ_DIR/.omao/triggers.json" ]]; then
+  TRIGGERS_JSON="$OMA_PROJ_DIR/.omao/triggers.json"
 fi
 
 # Graceful exit if triggers.json missing
@@ -118,7 +122,7 @@ done <<< "$TRIGGERS"
 # If any .omao/ontology/budgets/*.json has `spend_ratio > warn_at_pct/100`
 # we prepend a warning. This requires the user or agenticops to have written
 # a `spend_usd` value into the instance; otherwise we silently skip.
-if [[ "${OMA_DISABLE_ONTOLOGY:-0}" != "1" ]] && [[ -d ".omao/ontology/budgets" ]]; then
+if [[ "${OMA_DISABLE_ONTOLOGY:-0}" != "1" ]] && [[ -d "$OMA_PROJ_DIR/.omao/ontology/budgets" ]]; then
   while IFS= read -r f; do
     [[ -z "$f" ]] && continue
     warn_line=$(jq -r '
@@ -137,7 +141,7 @@ Consider running /oma:agenticops or pausing high-cost operations."
       jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
       exit 0
     fi
-  done < <(find .omao/ontology/budgets -maxdepth 1 -type f -name '*.json' 2>/dev/null)
+  done < <(find "$OMA_PROJ_DIR/.omao/ontology/budgets" -maxdepth 1 -type f -name '*.json' 2>/dev/null)
 fi
 
 # No match found

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -113,7 +113,12 @@ Description: $DESCRIPTION
 
 Invoke this command or proceed with the user's request using the relevant Tier-0 workflow."
 
-    jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
+    jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $ctx
+      }
+    }'
     exit 0
   fi
 done <<< "$TRIGGERS"
@@ -138,7 +143,12 @@ if [[ "${OMA_DISABLE_ONTOLOGY:-0}" != "1" ]] && [[ -d "$OMA_PROJ_DIR/.omao/ontol
 $warn_line
 
 Consider running /oma:agenticops or pausing high-cost operations."
-      jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
+      jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: $ctx
+        }
+      }'
       exit 0
     fi
   done < <(find "$OMA_PROJ_DIR/.omao/ontology/budgets" -maxdepth 1 -type f -name '*.json' 2>/dev/null)

--- a/tests/hooks/test_session_start.bats
+++ b/tests/hooks/test_session_start.bats
@@ -44,29 +44,29 @@ teardown() {
     cd "$PROJECT"
     run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("[OMA Ontology]")' >/dev/null
-    echo "$output" | jq -e '.additionalContext | contains("Budget default-monthly")' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("[OMA Ontology]")' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("Budget default-monthly")' >/dev/null
 }
 
 @test "session-start includes open incident" {
     cd "$PROJECT"
     run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("Incident inc-test-001")' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("Incident inc-test-001")' >/dev/null
 }
 
 @test "session-start includes proposed deployment" {
     cd "$PROJECT"
     run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("Deployment vllm-mini")' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("Deployment vllm-mini")' >/dev/null
 }
 
 @test "OMA_DISABLE_ONTOLOGY skips ontology block" {
     cd "$PROJECT"
     OMA_DISABLE_ONTOLOGY=1 run bash "$HOOK"
     [ "$status" -eq 0 ]
-    run jq -e '.additionalContext | contains("[OMA Ontology]") | not' <<<"$output"
+    run jq -e '.hookSpecificOutput.additionalContext | contains("[OMA Ontology]") | not' <<<"$output"
     [ "$status" -eq 0 ]
 }
 
@@ -75,5 +75,5 @@ teardown() {
     cd "$PROJECT"
     run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
 }


### PR DESCRIPTION
Issue #, if available:
  
(none)

Description of changes:

  Two pre-existing defects that prevent OMA hook output from reaching the Claude Code 2.x model context. Symptom in the wild: opening a fresh Claude session produces no visible effect
  from any OMA hook — OMA_TRIGGER keyword routing, OMA_BUDGET_WARN, the ontology status block, the active-mode reminder, and project memory all silently drop out.

Two root causes, fixed in two separate commits:

  1. hooks/{session-start,user-prompt-submit}.sh resolved .omao/... paths against the bare cwd. Claude Code spawns hooks from whichever directory claude was started in, which is not
  always the project root. The hook then failed to find .omao/triggers.json, .omao/state/active-mode, .omao/project-memory.json, .omao/ontology/, or .omao/ontology/budgets/ and exited
  zero with no signal. Both hooks now resolve every .omao/... path against $CLAUDE_PROJECT_DIR (Claude Code's standard project pointer, already documented in hooks/README.md
  registration examples), with $OMA_PROJECT_DIR and $PWD as fallbacks for non-Claude harnesses and local invocations.
  2. Both hooks emitted the legacy bare {additionalContext: "..."} JSON shape. Claude Code 2.x expects the wrapped envelope {hookSpecificOutput: {hookEventName, additionalContext}}.
  Without the wrapper, the hook output is silently ignored. All four emit sites (session-start: jq + python3 + python fallbacks; user-prompt-submit: trigger + budget branches) now use
  the wrapped form. Bats assertions in tests/hooks/test_session_start.bats migrated to the new jq path .hookSpecificOutput.additionalContext.

  Affected behaviors that recover with this PR:
  - Trigger keyword detection (/oma:agenticops, etc. routing on .omao/triggers.json)
  - OMA_BUDGET_WARN magic keyword (.omao/ontology/budgets/*.json over-threshold)
  - Ontology status block at session start (open incidents, proposed deployments, active budgets)
  - Active Tier-0 mode reminder (.omao/state/active-mode)
  - Project memory injection (.omao/project-memory.json)
  
  Verification:
  - Bats suite tests/hooks/test_session_start.bats green (5/5).
  - Manually verified against Claude Code 2.1.136 by opening a fresh session in a project root: hook output now reaches the model and surfaces in responses.
  - No new dependencies; no API or schema changes; no breaking changes for OMA users on Claude Code 1.x — but those users were not seeing hook output anyway, given the legacy form's
  behavior in 2.x is the user-impacting case.
  
  Confirmed against Anthropic's Claude Code 2.1.x hook reference (https://docs.claude.com/en/docs/claude-code/hooks) for the envelope schema.

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.