### PR TITLE
Feat/permission templates

### DIFF
--- a/.github/workflows/oma-foundation.yml
+++ b/.github/workflows/oma-foundation.yml
@@ -57,6 +57,16 @@ jobs:
 
       - name: Run shell tests (bats)
         run: |
+          # The installers shell out to `python3 -c "import yaml; ..."` to
+          # parse profile.yaml. setup-python puts PyYAML on the same python3
+          # the bats step inherits via $PATH, but the contract is load-bearing
+          # enough that we assert it explicitly — a missing dependency here
+          # used to surface as `claude.sh stamps the OMA permissions sentinel`
+          # (test 20) failing far downstream.
+          python3 -c "import yaml" || {
+              echo "PyYAML missing on the python3 the bats step inherits" >&2
+              exit 1
+          }
           bats tests/installer
           bats tests/profile
           bats tests/doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,24 @@ breaking changes to non-stable surfaces as documented in
 - `templates/permissions/{common,sandbox,staging,prod}.yaml` — abstract
   deny-rule templates scoped by `profile.yaml` `aws.environment`. Each
   template declares `deny.{bash,edit,write,mcp}` patterns plus
-  `auto_approve` defaults. Reference data only — no runtime effect until
-  the follow-up `install_permissions()` commit wires `oma setup` to
-  emit the rules into `.claude/settings.json` and Kiro `cli.json` /
-  `agents/*.agent.json`. See `templates/permissions/README.md` for the
+  `auto_approve` defaults. See `templates/permissions/README.md` for the
   schema and the abstract → harness mapping table.
+- `scripts/lib/permissions.sh` — shared resolver. Reads
+  `templates/permissions/<env>.yaml`, follows `extends` against
+  `common.yaml`, and emits a normalized JSON document plus Claude /
+  Kiro emitters (`perms_to_claude_deny`, `perms_to_kiro_autoapprove`).
+- `install_permissions()` in `scripts/install/{claude,kiro}.sh`:
+  Claude — append-uniq merge of `permissions.deny` into
+  `~/.claude/settings.json`; existing user-authored entries preserved.
+  Kiro — patch `~/.kiro/settings/cli.json` autoApprove and rewrite each
+  OMA-owned `~/.kiro/agents/*.agent.json` from the source repo (never
+  mutates the tracked repo files), tagging the result with
+  `_meta.oma_permissions_env` so the deny set is auditable from Kiro.
+  Hand-edited agent.json copies are detected and refused.
+- New install flags `--skip-permissions` / `OMA_SKIP_PERMISSIONS=1` and
+  override `OMA_PERMISSIONS_ENV=<env>` for CI smoke runs.
+- `scripts/oma/setup.sh` exports `OMA_PROJECT_DIR` so the install
+  scripts read the project's `.omao/profile.yaml`, not their own cwd.
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ breaking changes to non-stable surfaces as documented in
   `oma permissions show|path|--json` interface, install reflection,
   and the doctor warn-on-overlay-but-no-reinstall path. The lib suite
   also gains 6 unit cases for `perms_resolve_with_overlays`.
+- `oma setup` now seeds `<project>/.omao/permissions.yaml` from
+  `templates/permissions/overlay.yaml.tmpl` on first run. The seed is
+  fully commented out so it's a no-op overlay; users uncomment the
+  rules they need. Existing overlay files are preserved verbatim on
+  re-run. Two new bats cases in `tests/profile/test_setup_non_interactive.bats`
+  pin the no-op equivalence and the preservation behaviour.
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ breaking changes to non-stable surfaces as documented in
   override `OMA_PERMISSIONS_ENV=<env>` for CI smoke runs.
 - `scripts/oma/setup.sh` exports `OMA_PROJECT_DIR` so the install
   scripts read the project's `.omao/profile.yaml`, not their own cwd.
+- `tests/installer/test_permissions_lib.bats` and
+  `tests/installer/test_install_permissions.bats` — 26 bats cases
+  covering the resolver (extends-merge, env validation, sandbox/staging/
+  prod superset, emitter shape) and the end-to-end install path
+  (idempotency, user-entry preservation, `--skip-permissions`,
+  `OMA_PERMISSIONS_ENV` override, hand-edited agent refusal, source
+  repo cleanliness).
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,12 +164,13 @@ breaking changes to non-stable surfaces as documented in
   `{hookSpecificOutput: {hookEventName, additionalContext}}` instead
   of the bare `{additionalContext}` form. Claude Code 2.x ignores
   the legacy shape silently — the user sees no effect from any hook
-  output (trigger keywords, budget warnings, ontology status block,
-  active-mode reminder, project memory). Confirmed against
-  Anthropic's 2.1.x hook reference. Affected emit sites: session-start
-  jq + python3 + python fallbacks; user-prompt-submit trigger and
-  budget branches. Existing bats assertions migrated to the new jq
-  path `.hookSpecificOutput.additionalContext`.
+  output (drift alerts, trigger keywords, budget warnings, ontology
+  status block, active-mode reminder, project memory). Confirmed
+  against Anthropic's 2.1.x hook reference. Affected emit sites:
+  session-start jq + python3 + python fallbacks; user-prompt-submit
+  trigger, budget, and permission-drift branches. Existing bats
+  assertions migrated to the new jq path
+  `.hookSpecificOutput.additionalContext`.
 - `hooks/{session-start,user-prompt-submit}.sh` now resolve every
   `.omao/...` path against `$CLAUDE_PROJECT_DIR` (with `OMA_PROJECT_DIR`
   and `$PWD` as fallbacks) instead of the bare cwd. Claude Code spawns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ breaking changes to non-stable surfaces as documented in
   `oma permissions show|path|--json` interface, install reflection,
   and the doctor warn-on-overlay-but-no-reinstall path. The lib suite
   also gains 6 unit cases for `perms_resolve_with_overlays`.
+- `hooks/session-start.sh` emits a new
+  `[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]` line when
+  `.omao/permissions.yaml` has been edited more recently than
+  `~/.claude/settings.json` or `~/.kiro/settings/cli.json`. The model
+  surfaces a reminder to re-run `oma setup`. Kill switch:
+  `OMA_DISABLE_PERMISSIONS_DRIFT=1`. 4 new bats cases in
+  `tests/hooks/test_session_start.bats` cover newer-overlay,
+  newer-settings, kill switch, and missing-harness-config paths.
 - `oma setup` now seeds `<project>/.omao/permissions.yaml` from
   `templates/permissions/overlay.yaml.tmpl` on first run. The seed is
   fully commented out so it's a no-op overlay; users uncomment the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,21 @@ breaking changes to non-stable surfaces as documented in
   (`.omao/project-memory.json`), ontology status block
   (`.omao/ontology/`), and the budget warning
   (`.omao/ontology/budgets/`).
+- `scripts/install/{claude,kiro}.sh` `install_permissions`: when the
+  PyYAML fallback path runs `python3 -c "import sys, yaml; ..."` against
+  `.omao/profile.yaml` and PyYAML is missing on the inherited python3,
+  the invocation used to dump a traceback to stderr and an empty stdout,
+  silently collapsing `env=""` and skipping the entire permissions step.
+  CI test 20 (`claude.sh stamps the OMA permissions sentinel`) failed
+  downstream when this happened. The fallback now probes `import yaml`
+  first and `die`s with a clear remediation message
+  (`pip install pyyaml`, or set `OMA_PERMISSIONS_ENV` /
+  `OMA_SKIP_PERMISSIONS=1`). The bats sentinel assertions also capture
+  the install status + output so any future regression surfaces here
+  instead of as a confusing `[ -f sentinel ]` failure two lines later.
+  `.github/workflows/oma-foundation.yml` adds a `python3 -c "import
+  yaml"` smoke check before the bats step so the missing dependency is
+  named at the top of the failure log.
 - `perms_overlay_drift` now compares `.omao/permissions.yaml` against
   OMA-owned sentinel files (`<harness_home>/.oma-permissions-applied-at`)
   instead of the harness config (`settings.json` / `cli.json`). Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ breaking changes to non-stable surfaces as documented in
   (idempotency, user-entry preservation, `--skip-permissions`,
   `OMA_PERMISSIONS_ENV` override, hand-edited agent refusal, source
   repo cleanliness).
+- New `permissions-applied` probe in `scripts/oma/doctor.sh` (13th
+  probe). Reports pass when `~/.claude/settings.json` deny set is a
+  superset of the resolved env template AND every Kiro
+  `~/.kiro/agents/*.agent.json` carries a matching
+  `_meta.oma_permissions_env`. Skips cleanly when no profile or no
+  harness install is detected; warns and points at `oma setup` when
+  drift is detected. `bin/oma` help reflects the new count.
+- `tests/installer/test_doctor_permissions.bats` — 9 cases pinning
+  the probe through skip / pass / warn paths for both harnesses,
+  including profile env-mismatch and missing/unsupported
+  aws.environment.
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,19 @@ breaking changes to non-stable surfaces as documented in
   (`.omao/project-memory.json`), ontology status block
   (`.omao/ontology/`), and the budget warning
   (`.omao/ontology/budgets/`).
+- `scripts/lib/permissions.sh` `merge_one`: child template's explicit
+  `auto_approve.{read_only,file_writes,bash_commands}: false` now
+  overrides a parent's `true`. The previous `(child.k // parent.k)`
+  collapsed `false` into the parent value because jq's `//` operator
+  treats `false` as a null alternative. New `pick_scalar` helper uses
+  `has(k)` so child intent is honored regardless of the literal value.
+  Regression caught by `tests/installer/test_permissions_lib.bats`.
+- `scripts/install/claude.sh` `detect_claude_version`: trailing
+  `| awk '{print $1}' || true` keeps the silent-fallback intent under
+  `set -euo pipefail`. Wrapper `claude` binaries (toolbox / asdf /
+  similar) that exit non-zero on stale state no longer abort the
+  installer. The bug pre-dates this change set but only surfaced
+  through the new `tests/installer/test_doctor_permissions.bats`.
 
 ## [0.4.0-preview.1] — 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,27 @@ breaking changes to non-stable surfaces as documented in
   the probe through skip / pass / warn paths for both harnesses,
   including profile env-mismatch and missing/unsupported
   aws.environment.
+- **Project-level permission overlay**:
+  `<project>/.omao/permissions.yaml` is now read on top of the
+  `common + <env>.yaml` chain. Overlay supports
+  `deny.add.{bash,edit,write,mcp}`, `deny.remove.{...}`, and
+  `auto_approve.{...}` overrides. `scripts/lib/permissions.sh` gains
+  `perms_apply_overlay` and `perms_resolve_with_overlays`; both install
+  scripts and the doctor probe call the new resolver so the overlay is
+  reflected in `~/.claude/settings.json`, Kiro autoApprove, and the
+  doctor superset check.
+- `oma permissions [show|path]` subcommand
+  (`scripts/oma/permissions.sh`). `show` prints the resolved chain with
+  per-entry provenance (`common.yaml` / `<env>.yaml` / `overlay`) plus
+  overlay add/remove counts; `--json` emits machine-readable output.
+  `path` prints `<project>/.omao/permissions.yaml` and creates the
+  parent directory so `$EDITOR $(oma permissions path)` works
+  immediately. Registered in `bin/oma`.
+- `tests/installer/test_permissions_overlay.bats` — 9 cases covering
+  the overlay add/remove/auto_approve semantics, the
+  `oma permissions show|path|--json` interface, install reflection,
+  and the doctor warn-on-overlay-but-no-reinstall path. The lib suite
+  also gains 6 unit cases for `perms_resolve_with_overlays`.
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,17 @@ breaking changes to non-stable surfaces as documented in
   (`.omao/project-memory.json`), ontology status block
   (`.omao/ontology/`), and the budget warning
   (`.omao/ontology/budgets/`).
+- `perms_overlay_drift` now compares `.omao/permissions.yaml` against
+  OMA-owned sentinel files (`<harness_home>/.oma-permissions-applied-at`)
+  instead of the harness config (`settings.json` / `cli.json`). Both
+  Claude Code and Kiro touch their own settings files for unrelated
+  reasons (session telemetry, model cache); using their mtime caused
+  the drift hook to silently false-negative as soon as the harness
+  bumped its config timestamp. install_permissions in both install
+  scripts now stamps a sentinel after a successful merge, and a harness
+  with no sentinel is treated as "never installed" — no false-positive
+  alerts on Kiro-less workstations either. Bats coverage updated to
+  exercise the sentinel mtime semantics.
 - `scripts/lib/permissions.sh` `merge_one`: child template's explicit
   `auto_approve.{read_only,file_writes,bash_commands}: false` now
   overrides a parent's `true`. The previous `(child.k // parent.k)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,14 @@ breaking changes to non-stable surfaces as documented in
   with no sentinel is treated as "never installed" — no false-positive
   alerts on Kiro-less workstations either. Bats coverage updated to
   exercise the sentinel mtime semantics.
+- `hooks/{session-start,user-prompt-submit}.sh` now resolve every
+  `.omao/...` path against `$CLAUDE_PROJECT_DIR` (with `OMA_PROJECT_DIR`
+  and `$PWD` as fallbacks) instead of the bare cwd. Claude Code spawns
+  hooks from whichever directory `claude` was invoked in, so the
+  previous relative-path lookups silently skipped when the cwd
+  diverged from the project root. Drift detection, trigger matching,
+  active-mode reminder, project-memory loading, ontology status block,
+  and the budget warning are all on the new resolution.
 - `scripts/lib/permissions.sh` `merge_one`: child template's explicit
   `auto_approve.{read_only,file_writes,bash_commands}: false` now
   overrides a parent's `true`. The previous `(child.k // parent.k)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ breaking changes to non-stable surfaces as documented in
   agenticops feedback-loop skills. OMA ships no trace MCP and runs no
   Langfuse — it defines the `mcp__<server_name>__*` socket; the user
   supplies the server. Registered the Langfuse Public API in REFERENCES.
+- `templates/permissions/{common,sandbox,staging,prod}.yaml` — abstract
+  deny-rule templates scoped by `profile.yaml` `aws.environment`. Each
+  template declares `deny.{bash,edit,write,mcp}` patterns plus
+  `auto_approve` defaults. Reference data only — no runtime effect until
+  the follow-up `install_permissions()` commit wires `oma setup` to
+  emit the rules into `.claude/settings.json` and Kiro `cli.json` /
+  `agents/*.agent.json`. See `templates/permissions/README.md` for the
+  schema and the abstract → harness mapping table.
 
 ### Changed
 - **Observability is opt-in (default `none`).** `oma setup` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,14 +94,23 @@ breaking changes to non-stable surfaces as documented in
   `oma permissions show|path|--json` interface, install reflection,
   and the doctor warn-on-overlay-but-no-reinstall path. The lib suite
   also gains 6 unit cases for `perms_resolve_with_overlays`.
-- `hooks/session-start.sh` emits a new
+- `hooks/{session-start,user-prompt-submit}.sh` emit a new
   `[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]` line when
   `.omao/permissions.yaml` has been edited more recently than
-  `~/.claude/settings.json` or `~/.kiro/settings/cli.json`. The model
-  surfaces a reminder to re-run `oma setup`. Kill switch:
-  `OMA_DISABLE_PERMISSIONS_DRIFT=1`. 4 new bats cases in
-  `tests/hooks/test_session_start.bats` cover newer-overlay,
-  newer-settings, kill switch, and missing-harness-config paths.
+  `~/.claude/settings.json` or `~/.kiro/settings/cli.json`. The
+  per-prompt hook is the load-bearing one: a yaml edit is reflected
+  on the very next prompt, not just the next session. Detection is a
+  pure mtime check shared via `perms_overlay_drift` in
+  `scripts/lib/permissions.sh`. Kill switch:
+  `OMA_DISABLE_PERMISSIONS_DRIFT=1`. 9 new bats cases across
+  `tests/hooks/test_session_start.bats` and
+  `tests/hooks/test_user_prompt_submit_drift.bats` cover newer-overlay,
+  newer-settings, kill switch, missing-harness-config, and "trigger
+  keyword still wins" paths.
+- `hooks/user-prompt-submit.sh` no longer exits early on an empty
+  triggers list — the budget warning and the new drift block need
+  to run regardless. Triggers loop is now properly conditional on
+  non-empty `TRIGGERS`.
 - `oma setup` now seeds `<project>/.omao/permissions.yaml` from
   `templates/permissions/overlay.yaml.tmpl` on first run. The seed is
   fully commented out so it's a no-op overlay; users uncomment the

--- a/bin/oma
+++ b/bin/oma
@@ -61,6 +61,9 @@ Subcommands:
     status      Read .omao/profile.yaml and summarize active mode, budgets, last doctor.
     enterprise-status
                 Summarize enterprise readiness: probe results + phased-adoption stage counters.
+    permissions Inspect the resolved permission chain (templates + overlay).
+                Use \`oma permissions show\` to see provenance,
+                \`oma permissions path\` to print the overlay file path.
     where       Print the OMA install root and key subdirectories.
     upgrade     git pull + re-run setup --migrate (clone installs only).
     uninstall   Reverse symlinks and surgically remove OMA entries from ~/.claude/settings.json.

--- a/bin/oma
+++ b/bin/oma
@@ -54,7 +54,7 @@ Usage: oma <subcommand> [options]
 Subcommands:
     setup       Interactive setup: profile wizard, install plugins, seed ontology, doctor.
     init        Scaffold .omao/ in the current project (subset of setup).
-    doctor      Run 12 environment probes; exit 0 all-pass / 1 warn / 2 fail.
+    doctor      Run 13 environment probes; exit 0 all-pass / 1 warn / 2 fail.
     compile     Compile every plugin's *.oma.yaml into native .mcp.json / agent.json files.
     validate    Validate a Deployment YAML against the ontology + active OPA policies.
     run-workflow Resolve and print workflow DAG execution plan (stub: no invocation yet).

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -51,7 +51,9 @@ Triggered on every user prompt. Reads `.omao/triggers.json` and checks for keywo
 - **Keyword detection**: Case-insensitive matching against trigger keywords
 - **Context validation**: Ensures required context tokens are present (e.g., "autopilot" requires "aidlc")
 - **Output**: Emits `additionalContext` JSON with suggested command if a match is found
-- **Kill switch**: Set `OMA_DISABLE_TRIGGERS=1` to disable
+- **Budget warning**: Same `OMA_BUDGET_WARN` block as session-start (overflow path).
+- **Permissions drift**: When no trigger and no budget warning fire, compares `.omao/permissions.yaml` mtime against `~/.claude/settings.json` and `~/.kiro/settings/cli.json`. Emits `[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]` so the model nudges the user to re-run install on the **next prompt**, not just the next session. Kill switch: `OMA_DISABLE_PERMISSIONS_DRIFT=1`.
+- **Kill switch**: Set `OMA_DISABLE_TRIGGERS=1` to disable trigger detection
 
 Example trigger detection:
 ```

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -66,8 +66,9 @@ Triggered at session start. Injects project context:
 
 - **Active mode reminder**: Reads `.omao/state/active-mode` and warns if a Tier-0 workflow is running
 - **Project memory**: Loads `.omao/project-memory.json` content
+- **Permissions drift**: Compares `.omao/permissions.yaml` mtime against `~/.claude/settings.json` and `~/.kiro/settings/cli.json`. If the overlay is newer, emits `[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]` so the model reminds the user to re-run `oma setup`. Kill switch: `OMA_DISABLE_PERMISSIONS_DRIFT=1`.
 - **Command reference**: Lists all available OMA Tier-0 commands
-- **Kill switch**: Set `OMA_DISABLE_TRIGGERS=1` to disable
+- **Kill switch**: Set `OMA_DISABLE_TRIGGERS=1` to disable the entire hook
 
 ## Triggers Catalog
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -88,6 +88,40 @@ $ONTOLOGY_BLOCK
   fi
 fi
 
+# ----- Permission overlay drift detection ----------------------------------
+# If .omao/permissions.yaml has been edited more recently than the harness
+# config it lands in, surface a one-line reminder so the user knows to
+# re-run `oma setup` (or scripts/install/{claude,kiro}.sh) before the next
+# session relies on stale deny rules.
+#
+# Heuristic: mtime comparison only. We don't open the YAML — same kill
+# switch family as the other ontology probes (OMA_DISABLE_PERMISSIONS_DRIFT=1).
+if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]] && [[ -f ".omao/permissions.yaml" ]]; then
+  overlay_mtime=$(stat -f %m ".omao/permissions.yaml" 2>/dev/null || stat -c %Y ".omao/permissions.yaml" 2>/dev/null || echo 0)
+  drifted=""
+  for cfg in "$HOME/.claude/settings.json" "$HOME/.kiro/settings/cli.json"; do
+    [[ -f "$cfg" ]] || continue
+    cfg_mtime=$(stat -f %m "$cfg" 2>/dev/null || stat -c %Y "$cfg" 2>/dev/null || echo 0)
+    if [[ "$overlay_mtime" -gt "$cfg_mtime" ]]; then
+      drifted+="${drifted:+, }${cfg/#$HOME/~}"
+    fi
+  done
+  if [[ -n "$drifted" ]]; then
+    ADDITIONAL_CONTEXT+="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
+
+.omao/permissions.yaml has been edited more recently than: $drifted
+
+The new overlay is NOT yet reflected in your harness config. Run one of:
+  oma setup --skip-doctor
+  bash scripts/install/claude.sh
+  bash scripts/install/kiro.sh
+
+Use \`oma permissions show\` to preview the resolved chain before applying.
+
+"
+  fi
+fi
+
 # Add OMA command reference
 ADDITIONAL_CONTEXT+="Available OMA Tier-0 Commands:
 - /oma:autopilot           — AIDLC full-loop autopilot (Inception→Construction→Operations)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -101,7 +101,7 @@ if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]]; then
   if [[ -f "$__oma_repo_root/scripts/lib/permissions.sh" ]]; then
     # shellcheck disable=SC1091
     . "$__oma_repo_root/scripts/lib/permissions.sh"
-    drifted=$(perms_overlay_drift "$PWD" "$HOME" 2>/dev/null || true)
+    drifted=$(perms_overlay_drift "$OMA_PROJ_DIR" "$HOME" 2>/dev/null || true)
     if [[ -n "$drifted" ]]; then
       ADDITIONAL_CONTEXT+="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -89,25 +89,21 @@ $ONTOLOGY_BLOCK
 fi
 
 # ----- Permission overlay drift detection ----------------------------------
-# If .omao/permissions.yaml has been edited more recently than the harness
-# config it lands in, surface a one-line reminder so the user knows to
-# re-run `oma setup` (or scripts/install/{claude,kiro}.sh) before the next
-# session relies on stale deny rules.
-#
-# Heuristic: mtime comparison only. We don't open the YAML — same kill
-# switch family as the other ontology probes (OMA_DISABLE_PERMISSIONS_DRIFT=1).
-if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]] && [[ -f ".omao/permissions.yaml" ]]; then
-  overlay_mtime=$(stat -f %m ".omao/permissions.yaml" 2>/dev/null || stat -c %Y ".omao/permissions.yaml" 2>/dev/null || echo 0)
-  drifted=""
-  for cfg in "$HOME/.claude/settings.json" "$HOME/.kiro/settings/cli.json"; do
-    [[ -f "$cfg" ]] || continue
-    cfg_mtime=$(stat -f %m "$cfg" 2>/dev/null || stat -c %Y "$cfg" 2>/dev/null || echo 0)
-    if [[ "$overlay_mtime" -gt "$cfg_mtime" ]]; then
-      drifted+="${drifted:+, }${cfg/#$HOME/~}"
-    fi
-  done
-  if [[ -n "$drifted" ]]; then
-    ADDITIONAL_CONTEXT+="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
+# Surface a one-liner when .omao/permissions.yaml has been edited more
+# recently than the harness config the install scripts wrote to. The actual
+# detection lives in scripts/lib/permissions.sh so user-prompt-submit.sh
+# can reuse it on every keystroke.
+if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]]; then
+  __oma_repo_root="${OMA_REPO_ROOT:-}"
+  if [[ -z "$__oma_repo_root" ]]; then
+    __oma_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)" || __oma_repo_root=""
+  fi
+  if [[ -f "$__oma_repo_root/scripts/lib/permissions.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "$__oma_repo_root/scripts/lib/permissions.sh"
+    drifted=$(perms_overlay_drift "$PWD" "$HOME" 2>/dev/null || true)
+    if [[ -n "$drifted" ]]; then
+      ADDITIONAL_CONTEXT+="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
 
 .omao/permissions.yaml has been edited more recently than: $drifted
 
@@ -119,6 +115,7 @@ The new overlay is NOT yet reflected in your harness config. Run one of:
 Use \`oma permissions show\` to preview the resolved chain before applying.
 
 "
+    fi
   fi
 fi
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -182,7 +182,12 @@ The new overlay is NOT yet reflected in your harness config. Run one of:
   bash scripts/install/kiro.sh
 
 Use \`oma permissions show\` to preview the resolved chain before applying."
-      jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
+      jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: $ctx
+        }
+      }'
       exit 0
     fi
   fi

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -170,7 +170,7 @@ if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]]; then
   if [[ -f "$__oma_repo_root/scripts/lib/permissions.sh" ]]; then
     # shellcheck disable=SC1091
     . "$__oma_repo_root/scripts/lib/permissions.sh"
-    drifted=$(perms_overlay_drift "$PWD" "$HOME" 2>/dev/null || true)
+    drifted=$(perms_overlay_drift "$OMA_PROJ_DIR" "$HOME" 2>/dev/null || true)
     if [[ -n "$drifted" ]]; then
       ADDITIONAL_CONTEXT="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -47,9 +47,9 @@ PROMPT_LOWER=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')
 # Parse triggers.json
 TRIGGERS=$(jq -c '.triggers[]' "$TRIGGERS_JSON" 2>/dev/null || echo "")
 
-if [[ -z "$TRIGGERS" ]]; then
-  exit 0
-fi
+# Empty triggers list is fine — drift detection and budget warnings below
+# still need to run. We just skip the per-trigger loop in that case.
+if [[ -n "$TRIGGERS" ]]; then
 
 # Iterate through triggers
 while IFS= read -r trigger; do
@@ -123,6 +123,8 @@ Invoke this command or proceed with the user's request using the relevant Tier-0
   fi
 done <<< "$TRIGGERS"
 
+fi  # close: if [[ -n "$TRIGGERS" ]]
+
 # ----- Ontology-aware budget warning -----------------------------------------
 # If any .omao/ontology/budgets/*.json has `spend_ratio > warn_at_pct/100`
 # we prepend a warning. This requires the user or agenticops to have written
@@ -152,6 +154,38 @@ Consider running /oma:agenticops or pausing high-cost operations."
       exit 0
     fi
   done < <(find "$OMA_PROJ_DIR/.omao/ontology/budgets" -maxdepth 1 -type f -name '*.json' 2>/dev/null)
+fi
+
+# ----- Permission overlay drift detection -----------------------------------
+# Last-priority check: if no trigger matched and no budget warning fired,
+# remind the user when .omao/permissions.yaml has been edited more recently
+# than the harness config the install scripts wrote. Surfaces on every
+# prompt until the user re-runs install. Kill switch:
+# OMA_DISABLE_PERMISSIONS_DRIFT=1.
+if [[ "${OMA_DISABLE_PERMISSIONS_DRIFT:-0}" != "1" ]]; then
+  __oma_repo_root="${OMA_REPO_ROOT:-}"
+  if [[ -z "$__oma_repo_root" ]]; then
+    __oma_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)" || __oma_repo_root=""
+  fi
+  if [[ -f "$__oma_repo_root/scripts/lib/permissions.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "$__oma_repo_root/scripts/lib/permissions.sh"
+    drifted=$(perms_overlay_drift "$PWD" "$HOME" 2>/dev/null || true)
+    if [[ -n "$drifted" ]]; then
+      ADDITIONAL_CONTEXT="[MAGIC KEYWORD: OMA_PERMISSIONS_DRIFT]
+
+.omao/permissions.yaml has been edited more recently than: $drifted
+
+The new overlay is NOT yet reflected in your harness config. Run one of:
+  oma setup --skip-doctor
+  bash scripts/install/claude.sh
+  bash scripts/install/kiro.sh
+
+Use \`oma permissions show\` to preview the resolved chain before applying."
+      jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{"additionalContext": $ctx}'
+      exit 0
+    fi
+  fi
 fi
 
 # No match found

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -275,6 +275,14 @@ install_permissions() {
 
     PERMISSIONS_ADDED="$added_count"
     log "permissions: $added_count new deny entries appended (total $(jq '.permissions.deny | length' "$settings"))"
+
+    # Stamp the OMA sentinel so the drift hook compares against our own
+    # timestamp, not against settings.json (which Claude itself touches
+    # for unrelated reasons). Sentinel lives at <CLAUDE_HOME>/.oma-permissions-applied-at.
+    sentinel="$CLAUDE_HOME/.oma-permissions-applied-at"
+    mkdir -p "$(dirname "$sentinel")"
+    : > "$sentinel"
+    log "permissions: stamped $sentinel"
 }
 
 detect_claude_version() {

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -229,6 +229,14 @@ install_permissions() {
             if command -v yq >/dev/null 2>&1; then
                 env="$(yq -r '.aws.environment // ""' "$profile")"
             elif command -v python3 >/dev/null 2>&1; then
+                # PyYAML must be importable; otherwise the python invocation
+                # writes a traceback to stderr and an empty stdout, which would
+                # silently collapse to env="" and skip the whole permissions
+                # step (CI test 20 regression). Fail loud so the installer
+                # output names the missing dependency.
+                if ! python3 -c "import yaml" >/dev/null 2>&1; then
+                    die "permissions: profile.yaml needs yq or PyYAML (pip install pyyaml); set OMA_PERMISSIONS_ENV=<env> or OMA_SKIP_PERMISSIONS=1 to bypass"
+                fi
                 env="$(python3 -c "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); print(d.get('aws',{}).get('environment',''))" "$profile")"
             fi
         fi

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -23,8 +23,11 @@ STEERING_CMDS_DIR="$OMA_REPO_DIR/steering/commands/oma"
 PLUGINS_INSTALLED=0
 MCP_SERVERS_MERGED=0
 HOOKS_REGISTERED=0
+PERMISSIONS_ADDED=0
+PERMISSIONS_ENV=""
 CLAUDE_MAJOR_VERSION=""
 CLAUDE_SUPPORTS_NATIVE=0
+SKIP_PERMISSIONS="${OMA_SKIP_PERMISSIONS:-0}"
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -34,11 +37,16 @@ usage() {
 install-claude.sh — Install oh-my-aidlcops (OMA) into ~/.claude/
 
 Usage:
-    bash scripts/install-claude.sh [--help] [--dry-run]
+    bash scripts/install-claude.sh [--help] [--dry-run] [--skip-permissions]
 
 Environment:
-    OMA_OWNER      GitHub owner for the marketplace (default: aws-samples).
-    CLAUDE_HOME    Target Claude directory (default: $HOME/.claude).
+    OMA_OWNER             GitHub owner for the marketplace (default: aws-samples).
+    CLAUDE_HOME           Target Claude directory (default: $HOME/.claude).
+    OMA_PROJECT_DIR       Project that holds .omao/profile.yaml. Used to pick
+                          the permission template (default: $PWD).
+    OMA_SKIP_PERMISSIONS  Set to 1 to skip the install_permissions step.
+    OMA_PERMISSIONS_ENV   Override the env (sandbox/staging/prod) regardless
+                          of profile.yaml. Useful for CI smoke tests.
 
 What it does:
     1. Create ~/.claude/plugins/<plugin>/ symlinks for every plugin listed in
@@ -48,6 +56,8 @@ What it does:
     3. Merge each plugin's .mcp.json mcpServers map into ~/.claude/settings.json
        non-destructively via jq.
     4. Register the OMA UserPromptSubmit and SessionStart hook scripts.
+    5. Merge env-scoped deny patterns from templates/permissions/ into
+       ~/.claude/settings.json `permissions.deny` (append-uniq).
 
 Dependencies: jq, bash 4+.
 The script is idempotent — re-running will refresh symlinks and re-merge only
@@ -197,6 +207,73 @@ install_hooks() {
     done
 }
 
+# Merge env-scoped deny patterns into ~/.claude/settings.json. Reads the
+# active environment from .omao/profile.yaml (or OMA_PERMISSIONS_ENV override),
+# resolves templates/permissions/<env>.yaml against common.yaml, and appends
+# unique entries to permissions.deny. Existing user-authored entries are
+# preserved verbatim — this function never deletes.
+install_permissions() {
+    if [ "$SKIP_PERMISSIONS" = 1 ]; then
+        log "permissions: skipped (OMA_SKIP_PERMISSIONS=1)"
+        return 0
+    fi
+
+    # shellcheck disable=SC1091
+    . "$OMA_REPO_DIR/scripts/lib/permissions.sh"
+
+    env="${OMA_PERMISSIONS_ENV:-}"
+    if [ -z "$env" ]; then
+        project_dir="${OMA_PROJECT_DIR:-$PWD}"
+        profile="$project_dir/.omao/profile.yaml"
+        if [ -f "$profile" ]; then
+            if command -v yq >/dev/null 2>&1; then
+                env="$(yq -r '.aws.environment // ""' "$profile")"
+            elif command -v python3 >/dev/null 2>&1; then
+                env="$(python3 -c "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); print(d.get('aws',{}).get('environment',''))" "$profile")"
+            fi
+        fi
+    fi
+
+    if [ -z "$env" ]; then
+        log "permissions: no .omao/profile.yaml aws.environment found; skipping (run 'oma setup' first)"
+        return 0
+    fi
+
+    case "$env" in
+        sandbox|staging|prod) ;;
+        *) warn "permissions: unsupported env '$env'; skipping"; return 0 ;;
+    esac
+
+    PERMISSIONS_ENV="$env"
+    resolved="$(perms_resolve "$env")"
+
+    log "permissions: applying template chain for env=$env"
+    perms_print_summary "$resolved" >&2
+
+    settings="$CLAUDE_HOME/settings.json"
+    [ -f "$settings" ] || printf '{}\n' > "$settings"
+
+    new_deny="$(printf '%s' "$resolved" | perms_to_claude_deny)"
+
+    # Count entries that aren't already present so the summary line is accurate.
+    added_count="$(jq --argjson new "$new_deny" '
+        ((.permissions.deny // []) | unique) as $cur
+        | [ $new[] | select(. as $x | $cur | index($x) | not) ]
+        | length
+    ' "$settings")"
+
+    tmp="$(mktemp)"
+    jq --argjson new "$new_deny" '
+        .permissions //= {}
+        | .permissions.deny //= []
+        | .permissions.deny = ((.permissions.deny + $new) | unique)
+    ' "$settings" > "$tmp"
+    mv "$tmp" "$settings"
+
+    PERMISSIONS_ADDED="$added_count"
+    log "permissions: $added_count new deny entries appended (total $(jq '.permissions.deny | length' "$settings"))"
+}
+
 detect_claude_version() {
     if ! command -v claude >/dev/null 2>&1; then
         CLAUDE_MAJOR_VERSION=""
@@ -217,6 +294,7 @@ Installation complete.
     plugins installed : $PLUGINS_INSTALLED
     MCP servers added : $MCP_SERVERS_MERGED
     hooks registered  : $HOOKS_REGISTERED
+    permission deny   : $PERMISSIONS_ADDED new entries${PERMISSIONS_ENV:+ (env=$PERMISSIONS_ENV)}
 EOF
 
     if [ "$CLAUDE_SUPPORTS_NATIVE" = 1 ]; then
@@ -260,13 +338,20 @@ EOF
 # Main
 # ---------------------------------------------------------------------------
 main() {
-    case "${1:-}" in
-        -h|--help) usage; exit 0 ;;
-        --dry-run)
-            log "dry-run mode not implemented; exiting without side effects"
-            exit 0
-            ;;
-    esac
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+            --dry-run)
+                log "dry-run mode not implemented; exiting without side effects"
+                exit 0
+                ;;
+            --skip-permissions)
+                SKIP_PERMISSIONS=1
+                shift
+                ;;
+            *) die "unknown argument: $1 (try --help)" ;;
+        esac
+    done
     require jq
     detect_claude_version
     log "OMA repo  : $OMA_REPO_DIR"
@@ -281,6 +366,7 @@ main() {
     install_commands
     install_mcp_servers
     install_hooks
+    install_permissions
     summary
 }
 

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -245,10 +245,13 @@ install_permissions() {
     esac
 
     PERMISSIONS_ENV="$env"
-    resolved="$(perms_resolve "$env")"
+    resolved="$(perms_resolve_with_overlays "$env" "${OMA_PROJECT_DIR:-$PWD}")"
 
     log "permissions: applying template chain for env=$env"
     perms_print_summary "$resolved" >&2
+    if [ "$(printf '%s' "$resolved" | jq -r '._meta.overlay_applied // false')" = "true" ]; then
+        log "permissions: overlay $(printf '%s' "$resolved" | jq -r '._meta.overlay_path') applied"
+    fi
 
     settings="$CLAUDE_HOME/settings.json"
     [ -f "$settings" ] || printf '{}\n' > "$settings"

--- a/scripts/install/claude.sh
+++ b/scripts/install/claude.sh
@@ -279,8 +279,11 @@ detect_claude_version() {
         CLAUDE_MAJOR_VERSION=""
         return 0
     fi
-    # Expected output shape: "2.1.123 (Claude Code)"
-    raw="$(claude --version 2>/dev/null | head -1 | awk '{print $1}')"
+    # Expected output shape: "2.1.123 (Claude Code)". Trailing `|| true`
+    # keeps the silent-fallback intent under `set -euo pipefail`: a wrapper
+    # `claude` (toolbox/asdf-style) that exits non-zero on stale state must
+    # not abort the entire installer here.
+    raw="$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || true)"
     CLAUDE_MAJOR_VERSION="${raw%%.*}"
     if [ -n "$CLAUDE_MAJOR_VERSION" ] && [ "$CLAUDE_MAJOR_VERSION" -ge 2 ] 2>/dev/null; then
         CLAUDE_SUPPORTS_NATIVE=1

--- a/scripts/install/kiro.sh
+++ b/scripts/install/kiro.sh
@@ -348,9 +348,11 @@ install_permissions() {
                 ' "$src_agent" > "$tmp"; then
                 # Replace whatever currently lives at $dst (symlink or
                 # OMA-meta-tagged file) with the freshly patched copy.
-                [ -e "$dst" ] || [ -L "$dst" ] && rm -f "$dst"
+                if [ -e "$dst" ] || [ -L "$dst" ]; then
+                    rm -f "$dst"
+                fi
                 mv "$tmp" "$dst"
-                log "permissions: wrote ${dst#$KIRO_HOME/}"
+                log "permissions: wrote ${dst#"$KIRO_HOME"/}"
                 PERMISSIONS_APPLIED=$((PERMISSIONS_APPLIED + 1))
             else
                 warn "permissions: failed to render $src_agent → $dst (left untouched)"

--- a/scripts/install/kiro.sh
+++ b/scripts/install/kiro.sh
@@ -254,6 +254,14 @@ install_permissions() {
             if command -v yq >/dev/null 2>&1; then
                 env="$(yq -r '.aws.environment // ""' "$profile")"
             elif command -v python3 >/dev/null 2>&1; then
+                # PyYAML must be importable; otherwise the python invocation
+                # writes a traceback to stderr and an empty stdout, which would
+                # silently collapse to env="" and skip the whole permissions
+                # step (CI test 20 regression). Fail loud so the installer
+                # output names the missing dependency.
+                if ! python3 -c "import yaml" >/dev/null 2>&1; then
+                    die "permissions: profile.yaml needs yq or PyYAML (pip install pyyaml); set OMA_PERMISSIONS_ENV=<env> or OMA_SKIP_PERMISSIONS=1 to bypass"
+                fi
                 env="$(python3 -c "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); print(d.get('aws',{}).get('environment',''))" "$profile")"
             fi
         fi

--- a/scripts/install/kiro.sh
+++ b/scripts/install/kiro.sh
@@ -363,6 +363,14 @@ install_permissions() {
             fi
         done
     done < <(jq -r '.plugins[].name' "$MARKETPLACE_JSON")
+
+    # Stamp the OMA sentinel so the drift hook compares against our own
+    # timestamp, not against cli.json (which Kiro itself touches for
+    # unrelated reasons). Sentinel: <KIRO_HOME>/.oma-permissions-applied-at.
+    sentinel="$KIRO_HOME/.oma-permissions-applied-at"
+    mkdir -p "$(dirname "$sentinel")"
+    : > "$sentinel"
+    log "permissions: stamped $sentinel"
 }
 
 summary() {

--- a/scripts/install/kiro.sh
+++ b/scripts/install/kiro.sh
@@ -23,6 +23,9 @@ KIRO_META_FOUND=0
 GUIDES_LINKED=0
 AGENTS_LINKED=0
 SETTINGS_INSTALLED=0
+PERMISSIONS_APPLIED=0
+PERMISSIONS_ENV=""
+SKIP_PERMISSIONS="${OMA_SKIP_PERMISSIONS:-0}"
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -32,11 +35,15 @@ usage() {
 install-kiro.sh — Install oh-my-aidlcops (OMA) into ~/.kiro/
 
 Usage:
-    bash scripts/install-kiro.sh [--help]
+    bash scripts/install-kiro.sh [--help] [--skip-permissions]
 
 Environment:
-    OMA_OWNER    GitHub owner for the marketplace (default: aws-samples).
-    KIRO_HOME    Target Kiro directory (default: $HOME/.kiro).
+    OMA_OWNER             GitHub owner for the marketplace (default: aws-samples).
+    KIRO_HOME             Target Kiro directory (default: $HOME/.kiro).
+    OMA_PROJECT_DIR       Project that holds .omao/profile.yaml. Used to pick
+                          the permission template (default: $PWD).
+    OMA_SKIP_PERMISSIONS  Set to 1 to skip the install_permissions step.
+    OMA_PERMISSIONS_ENV   Override the env (sandbox/staging/prod).
 
 What it does:
     1. Create ~/.kiro/skills/<plugin>/<skill>/ symlinks for every skill in every
@@ -47,6 +54,8 @@ What it does:
     5. Install default settings/cli.json template if not present.
     6. Emit a note for any SKILL.md that has a kiro.meta.yaml sidecar — Kiro
        reads those for trigger and context hints.
+    7. Apply env-scoped autoApprove from templates/permissions/ to
+       ~/.kiro/settings/cli.json and every linked agent.json (safe overlay).
 
 Dependencies: jq, bash 4+.
 Idempotent — re-running refreshes stale symlinks only.
@@ -216,6 +225,141 @@ install_settings() {
     log "settings installed: $cli_json"
 }
 
+# Apply env-scoped autoApprove from templates/permissions/ to:
+#   - ~/.kiro/settings/cli.json     (global default)
+#   - ~/.kiro/agents/*.agent.json   (per-agent, only the OMA-installed ones)
+#
+# Kiro has no permissions.deny list — it relies on autoApprove gates plus the
+# `tools` whitelist on each agent profile. We tighten autoApprove to whatever
+# the resolved template specifies; we do NOT touch the `tools` list because
+# that risks disabling MCP servers Kiro itself relies on.
+#
+# Resolved deny.bash / deny.edit / deny.write / deny.mcp patterns are mirrored
+# into agent.json `_meta.oma_permissions_deny` so they are auditable from the
+# Kiro side even though Kiro does not enforce them as a permission gate.
+install_permissions() {
+    if [ "$SKIP_PERMISSIONS" = 1 ]; then
+        log "permissions: skipped (OMA_SKIP_PERMISSIONS=1)"
+        return 0
+    fi
+
+    # shellcheck disable=SC1091
+    . "$OMA_REPO_DIR/scripts/lib/permissions.sh"
+
+    env="${OMA_PERMISSIONS_ENV:-}"
+    if [ -z "$env" ]; then
+        project_dir="${OMA_PROJECT_DIR:-$PWD}"
+        profile="$project_dir/.omao/profile.yaml"
+        if [ -f "$profile" ]; then
+            if command -v yq >/dev/null 2>&1; then
+                env="$(yq -r '.aws.environment // ""' "$profile")"
+            elif command -v python3 >/dev/null 2>&1; then
+                env="$(python3 -c "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); print(d.get('aws',{}).get('environment',''))" "$profile")"
+            fi
+        fi
+    fi
+
+    if [ -z "$env" ]; then
+        log "permissions: no .omao/profile.yaml aws.environment found; skipping (run 'oma setup' first)"
+        return 0
+    fi
+
+    case "$env" in
+        sandbox|staging|prod) ;;
+        *) warn "permissions: unsupported env '$env'; skipping"; return 0 ;;
+    esac
+
+    PERMISSIONS_ENV="$env"
+    resolved="$(perms_resolve "$env")"
+    autoapprove="$(printf '%s' "$resolved" | perms_to_kiro_autoapprove)"
+    deny_bash="$(printf  '%s' "$resolved" | jq '.deny.bash  // []')"
+    deny_edit="$(printf  '%s' "$resolved" | jq '.deny.edit  // []')"
+    deny_write="$(printf '%s' "$resolved" | jq '.deny.write // []')"
+    deny_mcp="$(printf   '%s' "$resolved" | jq '.deny.mcp   // []')"
+
+    log "permissions: applying template chain for env=$env"
+    perms_print_summary "$resolved" >&2
+
+    # 1) cli.json — global autoApprove. Other keys (defaultModel, steering, …)
+    #    preserved. Existing autoApprove keys win where the template did not
+    #    set them; template wins where it did (it is the security floor).
+    cli_json="$KIRO_HOME/settings/cli.json"
+    if [ -f "$cli_json" ]; then
+        tmp="$(mktemp)"
+        if jq --argjson a "$autoapprove" '.autoApprove = ((.autoApprove // {}) + $a)' "$cli_json" > "$tmp"; then
+            mv "$tmp" "$cli_json"
+            log "permissions: patched $cli_json autoApprove"
+            PERMISSIONS_APPLIED=$((PERMISSIONS_APPLIED + 1))
+        else
+            warn "permissions: failed to patch $cli_json (left untouched)"
+            rm -f "$tmp"
+        fi
+    else
+        log "permissions: $cli_json not present yet (run install_settings first); skipping cli.json"
+    fi
+
+    # 2) agents/*.agent.json — patch the user-side copies under
+    #    ~/.kiro/agents/, never the source repo files. install_agents has
+    #    already symlinked the source files into KIRO_HOME/agents/. We
+    #    materialize each OMA-owned symlink as a real copy on first run
+    #    so we never mutate the tracked repo files (and `git status`
+    #    stays clean).
+    agents_target="$KIRO_HOME/agents"
+    while IFS= read -r plugin; do
+        [ -n "$plugin" ] || continue
+        plugin_agents="$OMA_REPO_DIR/plugins/$plugin/kiro-agents"
+        [ -d "$plugin_agents" ] || continue
+        for src_agent in "$plugin_agents"/*.json; do
+            [ -f "$src_agent" ] || continue
+            agent_name="$(basename "$src_agent")"
+            dst="$agents_target/$agent_name"
+
+            # Always materialize from the source repo: drop any existing
+            # symlink, then write a patched real-file copy. This keeps user
+            # copies in sync with upstream agent.json updates while never
+            # mutating the tracked repo files. Refuse to overwrite a
+            # non-symlink, non-OMA-meta file so we never trample a user
+            # who hand-edited an agent profile.
+            if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+                if ! jq -e '._meta.oma_permissions_env' "$dst" >/dev/null 2>&1; then
+                    warn "permissions: refusing to overwrite hand-edited $dst (delete it to re-apply)"
+                    continue
+                fi
+            fi
+
+            ensure_dir "$agents_target"
+            tmp="$(mktemp)"
+            if jq \
+                --argjson a   "$autoapprove" \
+                --argjson db  "$deny_bash"   \
+                --argjson de  "$deny_edit"   \
+                --argjson dw  "$deny_write"  \
+                --argjson dm  "$deny_mcp"    \
+                --arg     env "$env"         '
+                .autoApprove = ((.autoApprove // {}) + $a)
+                | ._meta //= {}
+                | ._meta.oma_permissions_env = $env
+                | ._meta.oma_permissions_deny = {
+                    bash:  $db,
+                    edit:  $de,
+                    write: $dw,
+                    mcp:   $dm
+                  }
+                ' "$src_agent" > "$tmp"; then
+                # Replace whatever currently lives at $dst (symlink or
+                # OMA-meta-tagged file) with the freshly patched copy.
+                [ -e "$dst" ] || [ -L "$dst" ] && rm -f "$dst"
+                mv "$tmp" "$dst"
+                log "permissions: wrote ${dst#$KIRO_HOME/}"
+                PERMISSIONS_APPLIED=$((PERMISSIONS_APPLIED + 1))
+            else
+                warn "permissions: failed to render $src_agent → $dst (left untouched)"
+                rm -f "$tmp"
+            fi
+        done
+    done < <(jq -r '.plugins[].name' "$MARKETPLACE_JSON")
+}
+
 summary() {
     cat <<EOF
 
@@ -225,6 +369,7 @@ Installation complete.
     guides linked         : $GUIDES_LINKED
     agents linked         : $AGENTS_LINKED
     settings installed    : $SETTINGS_INSTALLED
+    permissions applied   : $PERMISSIONS_APPLIED files${PERMISSIONS_ENV:+ (env=$PERMISSIONS_ENV)}
 EOF
     if [ "$KIRO_META_FOUND" -gt 0 ]; then
         cat <<'NOTE'
@@ -253,9 +398,13 @@ NOTE
 # Main
 # ---------------------------------------------------------------------------
 main() {
-    case "${1:-}" in
-        -h|--help) usage; exit 0 ;;
-    esac
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+            --skip-permissions) SKIP_PERMISSIONS=1; shift ;;
+            *) die "unknown argument: $1 (try --help)" ;;
+        esac
+    done
     require jq
     log "OMA repo : $OMA_REPO_DIR"
     log "KIRO_HOME: $KIRO_HOME"
@@ -265,6 +414,7 @@ main() {
     install_guides
     install_agents
     install_settings
+    install_permissions
     summary
 }
 

--- a/scripts/install/kiro.sh
+++ b/scripts/install/kiro.sh
@@ -270,7 +270,7 @@ install_permissions() {
     esac
 
     PERMISSIONS_ENV="$env"
-    resolved="$(perms_resolve "$env")"
+    resolved="$(perms_resolve_with_overlays "$env" "${OMA_PROJECT_DIR:-$PWD}")"
     autoapprove="$(printf '%s' "$resolved" | perms_to_kiro_autoapprove)"
     deny_bash="$(printf  '%s' "$resolved" | jq '.deny.bash  // []')"
     deny_edit="$(printf  '%s' "$resolved" | jq '.deny.edit  // []')"
@@ -279,6 +279,9 @@ install_permissions() {
 
     log "permissions: applying template chain for env=$env"
     perms_print_summary "$resolved" >&2
+    if [ "$(printf '%s' "$resolved" | jq -r '._meta.overlay_applied // false')" = "true" ]; then
+        log "permissions: overlay $(printf '%s' "$resolved" | jq -r '._meta.overlay_path') applied"
+    fi
 
     # 1) cli.json — global autoApprove. Other keys (defaultModel, steering, …)
     #    preserved. Existing autoApprove keys win where the template did not

--- a/scripts/lib/permissions.sh
+++ b/scripts/lib/permissions.sh
@@ -288,28 +288,39 @@ perms_to_kiro_autoapprove() {
     '
 }
 
-# perms_overlay_drift <project_dir> [<harness_home_dir>]
-# Compare .omao/permissions.yaml mtime against ~/.claude/settings.json and
-# ~/.kiro/settings/cli.json. Print a comma-separated list of harness configs
-# that pre-date the overlay (newer overlay → drift) on stdout. Empty stdout
-# means "no drift".
+# perms_overlay_drift <project_dir> [<user_home>]
+# Compare .omao/permissions.yaml mtime against OMA-owned sentinels created
+# by install_permissions:
 #
-# Pure mtime check — no YAML parsing, no install side effects. Safe to call
-# from any hook on every keystroke.
+#   <user_home>/.claude/.oma-permissions-applied-at   (claude install)
+#   <user_home>/.kiro/.oma-permissions-applied-at     (kiro install)
 #
-# <harness_home_dir> defaults to $HOME so callers can stub it for tests.
+# Print a comma-separated list of sentinels that pre-date the overlay
+# (overlay newer → drift) on stdout. Empty stdout means "no drift".
+#
+# Why a sentinel instead of comparing against settings.json: Claude Code
+# and Kiro both touch their own settings files for unrelated reasons
+# (session telemetry, model cache, last-used timestamps). A sentinel
+# OMA owns is the only mtime that genuinely tracks "when did
+# install_permissions last apply the overlay". A harness with no
+# sentinel is treated as "never installed" — no false-positive drift
+# alerts on a Kiro-less workstation.
+#
+# Pure mtime check — no YAML parsing, no side effects.
 perms_overlay_drift() {
     project_dir="${1:-$PWD}"
-    harness_home="${2:-$HOME}"
+    user_home="${2:-$HOME}"
     overlay="$project_dir/.omao/permissions.yaml"
     [ -f "$overlay" ] || return 0
     overlay_mtime=$(stat -f %m "$overlay" 2>/dev/null || stat -c %Y "$overlay" 2>/dev/null || echo 0)
     drifted=""
-    for cfg in "$harness_home/.claude/settings.json" "$harness_home/.kiro/settings/cli.json"; do
-        [ -f "$cfg" ] || continue
-        cfg_mtime=$(stat -f %m "$cfg" 2>/dev/null || stat -c %Y "$cfg" 2>/dev/null || echo 0)
-        if [ "$overlay_mtime" -gt "$cfg_mtime" ]; then
-            label="${cfg/#$harness_home/~}"
+    for sentinel in \
+        "$user_home/.claude/.oma-permissions-applied-at" \
+        "$user_home/.kiro/.oma-permissions-applied-at"; do
+        [ -f "$sentinel" ] || continue   # never installed for this harness
+        sentinel_mtime=$(stat -f %m "$sentinel" 2>/dev/null || stat -c %Y "$sentinel" 2>/dev/null || echo 0)
+        if [ "$overlay_mtime" -gt "$sentinel_mtime" ]; then
+            label="${sentinel/#$user_home/~}"
             drifted+="${drifted:+, }$label"
         fi
     done

--- a/scripts/lib/permissions.sh
+++ b/scripts/lib/permissions.sh
@@ -3,8 +3,18 @@
 # and Kiro install scripts.
 #
 # Reads templates/permissions/<env>.yaml, resolves `extends` against
-# common.yaml, and emits a single normalized JSON document on stdout that
-# both install scripts can ingest without re-parsing YAML.
+# common.yaml, optionally applies a project-level overlay
+# (`<project>/.omao/permissions.yaml`), and emits a single normalized JSON
+# document on stdout that both install scripts can ingest without re-parsing
+# YAML.
+#
+# Resolution chain (lowest → highest priority):
+#   1. templates/permissions/common.yaml      (OMA repo, baseline floor)
+#   2. templates/permissions/<env>.yaml       (OMA repo, environment defaults)
+#   3. <project>/.omao/permissions.yaml       (user overlay, optional)
+#
+# The overlay can both add and remove rules, and override auto_approve flags.
+# See perms_apply_overlay below for the schema.
 #
 # Output schema (always present, may be empty arrays):
 #
@@ -146,6 +156,89 @@ EOF
         --argjson exts "$extends_array_json" \
         --arg main_name "${env}.yaml" \
         '._meta.templates = ($exts + [$main_name])'
+}
+
+# perms_apply_overlay <resolved-json> <overlay-yaml>
+# Apply a project overlay (`<project>/.omao/permissions.yaml`) on top of an
+# already-resolved template chain. Returns the merged JSON on stdout.
+#
+# Overlay schema (every key optional):
+#
+#   version: 1
+#   deny:
+#     add:                          # extra deny patterns to layer in
+#       bash:  ["<pattern>", ...]
+#       edit:  ["<glob>", ...]
+#       write: ["<glob>", ...]
+#       mcp:   ["<pattern>", ...]
+#     remove:                       # patterns to subtract from the resolved set
+#       bash:  ["<pattern>", ...]
+#       edit:  ["<glob>", ...]
+#       write: ["<glob>", ...]
+#       mcp:   ["<pattern>", ...]
+#   auto_approve:                   # any/all flags optional; explicit value wins
+#     read_only:     <bool>
+#     file_writes:   <bool>
+#     bash_commands: <bool>
+#
+# Removals are exact-match against the post-merge deny array (after
+# common+env have unioned). To remove a pattern that was introduced in
+# common.yaml, copy the exact string into deny.remove.<bucket>.
+perms_apply_overlay() {
+    resolved="$1"
+    overlay_yaml="$2"
+    if [ ! -f "$overlay_yaml" ]; then
+        printf '%s' "$resolved"
+        return 0
+    fi
+    overlay_json="$(perms_yaml_to_json "$overlay_yaml")"
+
+    jq -n \
+        --argjson r "$resolved" \
+        --argjson o "$overlay_json" \
+        --arg     overlay_path "$overlay_yaml" \
+        '
+        def union_uniq($a; $b): ($a + $b) | unique | sort;
+        def subtract($a; $b): $a | map(select(. as $x | $b | index($x) | not));
+        def pick_scalar(parent; child; key):
+          if (child // {}) | has(key) then child[key] else parent[key] end;
+
+        ($o.deny.add    // {}) as $add
+        | ($o.deny.remove // {}) as $rm
+        | ($o.auto_approve // {}) as $aa
+        | $r
+        | .deny.bash  = subtract(union_uniq(.deny.bash  // []; $add.bash  // []); $rm.bash  // [])
+        | .deny.edit  = subtract(union_uniq(.deny.edit  // []; $add.edit  // []); $rm.edit  // [])
+        | .deny.write = subtract(union_uniq(.deny.write // []; $add.write // []); $rm.write // [])
+        | .deny.mcp   = subtract(union_uniq(.deny.mcp   // []; $add.mcp   // []); $rm.mcp   // [])
+        | .auto_approve.read_only     = pick_scalar(.auto_approve // {}; $aa; "read_only")
+        | .auto_approve.file_writes   = pick_scalar(.auto_approve // {}; $aa; "file_writes")
+        | .auto_approve.bash_commands = pick_scalar(.auto_approve // {}; $aa; "bash_commands")
+        | ._meta.overlay_path = $overlay_path
+        | ._meta.overlay_applied = (
+            ((($add.bash  // []) | length) > 0) or
+            ((($add.edit  // []) | length) > 0) or
+            ((($add.write // []) | length) > 0) or
+            ((($add.mcp   // []) | length) > 0) or
+            ((($rm.bash   // []) | length) > 0) or
+            ((($rm.edit   // []) | length) > 0) or
+            ((($rm.write  // []) | length) > 0) or
+            ((($rm.mcp    // []) | length) > 0) or
+            (($aa | keys | length) > 0)
+          )
+        '
+}
+
+# perms_resolve_with_overlays <env> [<project_dir>]
+# Resolve templates/<env>.yaml and (if present) layer the project overlay
+# from <project_dir>/.omao/permissions.yaml on top. <project_dir> defaults
+# to $PWD.
+perms_resolve_with_overlays() {
+    env="$1"
+    project_dir="${2:-$PWD}"
+    base_resolved="$(perms_resolve "$env")"
+    overlay="$project_dir/.omao/permissions.yaml"
+    perms_apply_overlay "$base_resolved" "$overlay"
 }
 
 # perms_resolve_for_profile <profile.yaml>

--- a/scripts/lib/permissions.sh
+++ b/scripts/lib/permissions.sh
@@ -288,6 +288,34 @@ perms_to_kiro_autoapprove() {
     '
 }
 
+# perms_overlay_drift <project_dir> [<harness_home_dir>]
+# Compare .omao/permissions.yaml mtime against ~/.claude/settings.json and
+# ~/.kiro/settings/cli.json. Print a comma-separated list of harness configs
+# that pre-date the overlay (newer overlay → drift) on stdout. Empty stdout
+# means "no drift".
+#
+# Pure mtime check — no YAML parsing, no install side effects. Safe to call
+# from any hook on every keystroke.
+#
+# <harness_home_dir> defaults to $HOME so callers can stub it for tests.
+perms_overlay_drift() {
+    project_dir="${1:-$PWD}"
+    harness_home="${2:-$HOME}"
+    overlay="$project_dir/.omao/permissions.yaml"
+    [ -f "$overlay" ] || return 0
+    overlay_mtime=$(stat -f %m "$overlay" 2>/dev/null || stat -c %Y "$overlay" 2>/dev/null || echo 0)
+    drifted=""
+    for cfg in "$harness_home/.claude/settings.json" "$harness_home/.kiro/settings/cli.json"; do
+        [ -f "$cfg" ] || continue
+        cfg_mtime=$(stat -f %m "$cfg" 2>/dev/null || stat -c %Y "$cfg" 2>/dev/null || echo 0)
+        if [ "$overlay_mtime" -gt "$cfg_mtime" ]; then
+            label="${cfg/#$harness_home/~}"
+            drifted+="${drifted:+, }$label"
+        fi
+    done
+    printf '%s' "$drifted"
+}
+
 # perms_print_summary <resolved-json>
 # Human-readable one-screen summary, stderr-friendly. Used by install scripts.
 perms_print_summary() {

--- a/scripts/lib/permissions.sh
+++ b/scripts/lib/permissions.sh
@@ -98,6 +98,13 @@ $extends_list
 EOF
 
     # Merge: scalar override (last wins), arrays union+uniq+sort.
+    #
+    # auto_approve flags are tri-valued from jq's perspective: `true`, `false`,
+    # or "key absent". The naive `(child.k // parent.k)` collapses both `false`
+    # and missing into the parent value because jq's `//` treats `false` as a
+    # null alternative. That blocks any child template from overriding `true`
+    # back to `false` once a parent set it. Use explicit `has(k)` so a
+    # `false` literal in the child is honored.
     final_json="$(jq -n \
         --argjson bases "$bases_json" \
         --argjson main "$main_json" \
@@ -106,12 +113,15 @@ EOF
         '
         def union_uniq($a; $b): ($a + $b) | unique | sort;
 
+        def pick_scalar(parent; child; key):
+          if (child // {}) | has(key) then child[key] else parent[key] end;
+
         def merge_one(parent; child):
           {
             auto_approve: {
-              read_only:     ((child.auto_approve.read_only)     // parent.auto_approve.read_only),
-              file_writes:   ((child.auto_approve.file_writes)   // parent.auto_approve.file_writes),
-              bash_commands: ((child.auto_approve.bash_commands) // parent.auto_approve.bash_commands)
+              read_only:     pick_scalar(parent.auto_approve // {}; child.auto_approve // {}; "read_only"),
+              file_writes:   pick_scalar(parent.auto_approve // {}; child.auto_approve // {}; "file_writes"),
+              bash_commands: pick_scalar(parent.auto_approve // {}; child.auto_approve // {}; "bash_commands")
             },
             deny: {
               bash:  union_uniq(parent.deny.bash  // []; child.deny.bash  // []),

--- a/scripts/lib/permissions.sh
+++ b/scripts/lib/permissions.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# scripts/lib/permissions.sh — Permission-template loader shared by the Claude
+# and Kiro install scripts.
+#
+# Reads templates/permissions/<env>.yaml, resolves `extends` against
+# common.yaml, and emits a single normalized JSON document on stdout that
+# both install scripts can ingest without re-parsing YAML.
+#
+# Output schema (always present, may be empty arrays):
+#
+# {
+#   "auto_approve": {
+#     "read_only":     <bool>,
+#     "file_writes":   <bool>,
+#     "bash_commands": <bool>
+#   },
+#   "deny": {
+#     "bash":  ["<glob>", ...],
+#     "edit":  ["<glob>", ...],
+#     "write": ["<glob>", ...],
+#     "mcp":   ["<glob>", ...]
+#   },
+#   "_meta": {
+#     "env":       "<sandbox|staging|prod>",
+#     "templates": ["common.yaml", "<env>.yaml"]
+#   }
+# }
+#
+# Depends on scripts/lib/log.sh. Uses yq (preferred) or python3 (fallback).
+
+if [ "${__OMA_PERMS_LOADED:-0}" = 1 ]; then return 0; fi
+__OMA_PERMS_LOADED=1
+
+__oma_perms_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__oma_perms_lib_dir/log.sh"
+
+__oma_perms_repo_root() {
+    (cd "$__oma_perms_lib_dir/../.." && pwd)
+}
+
+# perms_template_dir
+# Prints the absolute path to templates/permissions/.
+perms_template_dir() {
+    printf '%s/templates/permissions' "$(__oma_perms_repo_root)"
+}
+
+# perms_yaml_to_json <yaml-file>
+# yq preferred for speed; python3 fallback.
+perms_yaml_to_json() {
+    file="$1"
+    [ -f "$file" ] || die "permission template not found: $file"
+    if command -v yq >/dev/null 2>&1; then
+        yq -o=json '.' "$file"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c "import sys, json, yaml; json.dump(yaml.safe_load(open(sys.argv[1], encoding='utf-8')), sys.stdout)" "$file"
+    else
+        die "need yq or python3 to parse YAML (install: brew install yq)"
+    fi
+}
+
+# perms_resolve <env>
+# Resolve <env>.yaml plus its `extends` chain into a single normalized JSON
+# document and print it on stdout. <env> ∈ sandbox|staging|prod.
+#
+# Resolution rules:
+#   - Each template named in `extends` is resolved before the current file.
+#   - `auto_approve.*` scalars: child overrides parent.
+#   - `deny.{bash,edit,write,mcp}` arrays: child UNION parent (uniq, sorted).
+#   - Unknown keys are ignored (forward-compat with future schema additions).
+perms_resolve() {
+    env="$1"
+    case "$env" in
+        sandbox|staging|prod) ;;
+        *) die "perms_resolve: invalid env '$env' (sandbox|staging|prod)" ;;
+    esac
+
+    tmpl_dir="$(perms_template_dir)"
+    main_yaml="$tmpl_dir/${env}.yaml"
+    [ -f "$main_yaml" ] || die "permission template missing: $main_yaml"
+
+    # Read main + extends (one level deep is sufficient for the current
+    # schema; deeper trees would just need recursion). Build a list of
+    # (name, json) pairs in resolution order: bases first, then main.
+    main_json="$(perms_yaml_to_json "$main_yaml")"
+    extends_list=$(printf '%s' "$main_json" | jq -r '.extends // [] | .[]?')
+
+    # Collect base JSON docs in order.
+    bases_json="[]"
+    while IFS= read -r base; do
+        [ -n "$base" ] || continue
+        base_path="$tmpl_dir/$base"
+        [ -f "$base_path" ] || die "extends references missing template: $base"
+        base_json="$(perms_yaml_to_json "$base_path")"
+        bases_json="$(printf '%s' "$bases_json" | jq --argjson b "$base_json" '. + [$b]')"
+    done <<EOF
+$extends_list
+EOF
+
+    # Merge: scalar override (last wins), arrays union+uniq+sort.
+    final_json="$(jq -n \
+        --argjson bases "$bases_json" \
+        --argjson main "$main_json" \
+        --arg env "$env" \
+        --arg main_name "${env}.yaml" \
+        '
+        def union_uniq($a; $b): ($a + $b) | unique | sort;
+
+        def merge_one(parent; child):
+          {
+            auto_approve: {
+              read_only:     ((child.auto_approve.read_only)     // parent.auto_approve.read_only),
+              file_writes:   ((child.auto_approve.file_writes)   // parent.auto_approve.file_writes),
+              bash_commands: ((child.auto_approve.bash_commands) // parent.auto_approve.bash_commands)
+            },
+            deny: {
+              bash:  union_uniq(parent.deny.bash  // []; child.deny.bash  // []),
+              edit:  union_uniq(parent.deny.edit  // []; child.deny.edit  // []),
+              write: union_uniq(parent.deny.write // []; child.deny.write // []),
+              mcp:   union_uniq(parent.deny.mcp   // []; child.deny.mcp   // [])
+            }
+          };
+
+        # Start with an empty default, fold bases left-to-right, then apply main.
+        ($bases | reduce .[] as $b ({
+            auto_approve: { read_only: false, file_writes: false, bash_commands: false },
+            deny: { bash: [], edit: [], write: [], mcp: [] }
+          }; merge_one(.; $b))) as $base_merged
+        | merge_one($base_merged; $main)
+        | . + { _meta: { env: $env } }
+        ')"
+
+    # Attach the resolved template chain (extends list + main file name).
+    extends_array_json="$(printf '%s' "$main_json" | jq '.extends // []')"
+    printf '%s' "$final_json" | jq \
+        --argjson exts "$extends_array_json" \
+        --arg main_name "${env}.yaml" \
+        '._meta.templates = ($exts + [$main_name])'
+}
+
+# perms_resolve_for_profile <profile.yaml>
+# Convenience: read aws.environment from a profile.yaml and call perms_resolve.
+perms_resolve_for_profile() {
+    profile="$1"
+    [ -f "$profile" ] || die "profile not found: $profile"
+    env=""
+    if command -v yq >/dev/null 2>&1; then
+        env="$(yq -r '.aws.environment // ""' "$profile")"
+    elif command -v python3 >/dev/null 2>&1; then
+        env="$(python3 -c "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); print(d.get('aws',{}).get('environment',''))" "$profile")"
+    else
+        die "need yq or python3 to read profile.yaml"
+    fi
+    if [ -z "$env" ]; then
+        warn "profile $profile has no aws.environment; defaulting to sandbox"
+        env="sandbox"
+    fi
+    perms_resolve "$env"
+}
+
+# perms_to_claude_deny <resolved-json>
+# Translate the abstract deny set into Claude Code permission strings.
+# Stdin: resolved JSON. Stdout: JSON array of strings ready to merge into
+# settings.json `permissions.deny`.
+perms_to_claude_deny() {
+    jq '
+        ((.deny.bash  // []) | map("Bash("  + . + ")"))
+        + ((.deny.edit  // []) | map("Edit("  + . + ")"))
+        + ((.deny.write // []) | map("Write(" + . + ")"))
+        + (.deny.mcp   // [])
+        | unique
+    '
+}
+
+# perms_to_kiro_autoapprove <resolved-json>
+# Stdin: resolved JSON. Stdout: JSON object suitable for Kiro cli.json /
+# agent.json `autoApprove` field.
+perms_to_kiro_autoapprove() {
+    jq -r '
+        {
+          readOnly:      .auto_approve.read_only,
+          fileWrites:    .auto_approve.file_writes,
+          bashCommands:  .auto_approve.bash_commands
+        }
+    '
+}
+
+# perms_print_summary <resolved-json>
+# Human-readable one-screen summary, stderr-friendly. Used by install scripts.
+perms_print_summary() {
+    json="$1"
+    printf '%s' "$json" | jq -r '
+        "  env       : " + ._meta.env,
+        "  templates : " + (._meta.templates | join(" + ")),
+        "  deny.bash : " + ((.deny.bash  // []) | length | tostring) + " patterns",
+        "  deny.edit : " + ((.deny.edit  // []) | length | tostring) + " globs",
+        "  deny.write: " + ((.deny.write // []) | length | tostring) + " globs",
+        "  deny.mcp  : " + ((.deny.mcp   // []) | length | tostring) + " patterns",
+        "  autoApprove.readOnly     : " + (.auto_approve.read_only     | tostring),
+        "  autoApprove.fileWrites   : " + (.auto_approve.file_writes   | tostring),
+        "  autoApprove.bashCommands : " + (.auto_approve.bash_commands | tostring)
+    '
+}

--- a/scripts/oma/doctor.sh
+++ b/scripts/oma/doctor.sh
@@ -196,7 +196,7 @@ probe_permissions_applied() {
            return ;;
     esac
 
-    expected_deny="$(perms_resolve "$env" 2>/dev/null | perms_to_claude_deny 2>/dev/null || echo '[]')"
+    expected_deny="$(perms_resolve_with_overlays "$env" "$PROJECT_DIR" 2>/dev/null | perms_to_claude_deny 2>/dev/null || echo '[]')"
 
     claude_settings="$HOME/.claude/settings.json"
     kiro_dir="$HOME/.kiro"

--- a/scripts/oma/doctor.sh
+++ b/scripts/oma/doctor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/oma/doctor.sh — OMA environment doctor.
 #
-# Runs 12 probes and emits a human-readable report (default) or
+# Runs 13 probes and emits a human-readable report (default) or
 # a machine-readable JSON report (`--json`). Exit codes:
 #   0 — all pass (skips allowed)
 #   1 — at least one warning (no failures)
@@ -10,7 +10,7 @@
 # Probes:
 #   bash-version, jq-installed, git-installed, python3-installed, uvx-installed,
 #   claude-cli, kiro-cli, claude-settings, mcp-pin-integrity, aws-credentials,
-#   profile-valid, ontology-valid
+#   profile-valid, ontology-valid, permissions-applied
 
 set -euo pipefail
 
@@ -162,6 +162,97 @@ probe_ontology_valid() {
     fi
 }
 
+probe_permissions_applied() {
+    profile="$PROJECT_DIR/.omao/profile.yaml"
+    if [ ! -f "$profile" ]; then
+        record permissions-applied "Permission templates applied" skip "no profile yet"
+        return
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        record permissions-applied "Permission templates applied" skip "jq missing"
+        return
+    fi
+
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/scripts/lib/permissions.sh"
+
+    env=""
+    if command -v yq >/dev/null 2>&1; then
+        env="$(yq -r '.aws.environment // ""' "$profile" 2>/dev/null || true)"
+    elif command -v python3 >/dev/null 2>&1; then
+        env="$(python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1])).get('aws',{}).get('environment',''))" "$profile" 2>/dev/null || true)"
+    fi
+    if [ -z "$env" ]; then
+        record permissions-applied "Permission templates applied" warn \
+            "profile.yaml missing aws.environment" \
+            "Edit .omao/profile.yaml or re-run \`oma setup\`."
+        return
+    fi
+    case "$env" in
+        sandbox|staging|prod) ;;
+        *) record permissions-applied "Permission templates applied" warn \
+                  "unsupported aws.environment: $env" \
+                  "Set aws.environment to sandbox|staging|prod and re-run \`oma setup\`."
+           return ;;
+    esac
+
+    expected_deny="$(perms_resolve "$env" 2>/dev/null | perms_to_claude_deny 2>/dev/null || echo '[]')"
+
+    claude_settings="$HOME/.claude/settings.json"
+    kiro_dir="$HOME/.kiro"
+    claude_present=0; kiro_present=0
+    [ -f "$claude_settings" ] && claude_present=1
+    [ -d "$kiro_dir/agents" ] && kiro_present=1
+    if [ "$claude_present" -eq 0 ] && [ "$kiro_present" -eq 0 ]; then
+        record permissions-applied "Permission templates applied" skip \
+            "no Claude or Kiro install detected"
+        return
+    fi
+
+    issues=""
+
+    if [ "$claude_present" -eq 1 ]; then
+        cur_deny="$(jq -c '.permissions.deny // []' "$claude_settings" 2>/dev/null || echo '[]')"
+        # Count expected entries that are NOT present in the live deny list.
+        missing="$(jq --argjson exp "$expected_deny" --argjson cur "$cur_deny" -nr '
+            [ $exp[] | select(. as $x | $cur | index($x) | not) ] | length
+        ')"
+        if [ "${missing:-0}" -gt 0 ]; then
+            issues="${issues:+$issues; }claude: $missing missing deny entries"
+        fi
+    fi
+
+    if [ "$kiro_present" -eq 1 ]; then
+        # Walk every OMA-installed agent.json and confirm the env tag matches.
+        mismatched=0; untagged=0
+        while IFS= read -r agent; do
+            [ -n "$agent" ] || continue
+            tag="$(jq -r '._meta.oma_permissions_env // empty' "$agent" 2>/dev/null || true)"
+            if [ -z "$tag" ]; then
+                untagged=$((untagged + 1))
+            elif [ "$tag" != "$env" ]; then
+                mismatched=$((mismatched + 1))
+            fi
+        done < <(find "$kiro_dir/agents" -maxdepth 1 -type f -name '*.agent.json' 2>/dev/null)
+
+        if [ "$untagged" -gt 0 ] || [ "$mismatched" -gt 0 ]; then
+            parts=""
+            [ "$untagged"   -gt 0 ] && parts="$untagged untagged"
+            [ "$mismatched" -gt 0 ] && parts="${parts:+$parts, }$mismatched env-mismatch"
+            issues="${issues:+$issues; }kiro: $parts"
+        fi
+    fi
+
+    if [ -z "$issues" ]; then
+        record permissions-applied "Permission templates applied" pass \
+            "env=$env applied to $( [ $claude_present = 1 ] && printf 'claude '; [ $kiro_present = 1 ] && printf 'kiro')"
+    else
+        record permissions-applied "Permission templates applied" warn \
+            "env=$env: $issues" \
+            "Re-run \`oma setup\` or \`bash scripts/install/{claude,kiro}.sh\`."
+    fi
+}
+
 # -----------------------------------------------------------------------------
 # Run all probes
 # -----------------------------------------------------------------------------
@@ -177,6 +268,7 @@ probe_mcp_pins
 probe_aws_credentials
 probe_profile_valid
 probe_ontology_valid
+probe_permissions_applied
 
 # -----------------------------------------------------------------------------
 # Emit report

--- a/scripts/oma/permissions.sh
+++ b/scripts/oma/permissions.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# scripts/oma/permissions.sh — inspect the resolved permission chain.
+#
+# Subcommands:
+#   show     Print the resolved deny set + auto_approve, with provenance:
+#            which template/overlay each entry came from.
+#   path     Print the absolute path of <project>/.omao/permissions.yaml,
+#            create the parent directory if needed (so the user can
+#            `$EDITOR (oma permissions path)` immediately).
+#
+# Reads .omao/profile.yaml from $PWD (or --project <dir>) for aws.environment.
+# Honors OMA_PERMISSIONS_ENV as an override.
+
+set -euo pipefail
+
+REPO_ROOT="${OMA_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/lib/log.sh"
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/lib/permissions.sh"
+
+PROJECT_DIR="$PWD"
+SUBCMD="show"
+FORMAT=pretty
+
+usage() {
+    cat <<'EOF'
+oma permissions — inspect resolved permission chain
+
+Usage:
+    oma permissions [show|path] [--project DIR] [--json]
+
+Subcommands:
+    show    Print the resolved deny set + auto_approve flags, with the
+            originating layer (template, env overlay, or project overlay)
+            for each entry.
+    path    Print the path of <project>/.omao/permissions.yaml so the
+            user can edit it (`$EDITOR $(oma permissions path)`).
+
+Options:
+    --project DIR   Project root that holds .omao/profile.yaml.
+                    Default: current working directory.
+    --json          Emit machine-readable JSON (show only).
+
+Environment:
+    OMA_PERMISSIONS_ENV   Override env (sandbox/staging/prod).
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        show|path) SUBCMD="$1"; shift ;;
+        --project) PROJECT_DIR="$2"; shift 2 ;;
+        --json)    FORMAT=json; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) die "unknown arg: $1 (try --help)" ;;
+    esac
+done
+
+# ---------------- path ----------------
+if [ "$SUBCMD" = "path" ]; then
+    target="$PROJECT_DIR/.omao/permissions.yaml"
+    mkdir -p "$(dirname "$target")"
+    printf '%s\n' "$target"
+    exit 0
+fi
+
+# ---------------- show ----------------
+profile="$PROJECT_DIR/.omao/profile.yaml"
+env="${OMA_PERMISSIONS_ENV:-}"
+if [ -z "$env" ]; then
+    if [ ! -f "$profile" ]; then
+        die "no .omao/profile.yaml at $PROJECT_DIR (run \`oma setup\` first or pass --project)"
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        env="$(yq -r '.aws.environment // ""' "$profile")"
+    else
+        env="$(python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1])).get('aws',{}).get('environment',''))" "$profile" 2>/dev/null || true)"
+    fi
+fi
+case "$env" in
+    sandbox|staging|prod) ;;
+    *) die "unsupported aws.environment: '$env' (sandbox|staging|prod)" ;;
+esac
+
+# Build provenance: resolve each layer in isolation so we know which entries
+# come from where. Order: common.yaml, <env>.yaml-additions, overlay-add,
+# overlay-remove (subtraction).
+common_json="$(perms_yaml_to_json "$REPO_ROOT/templates/permissions/common.yaml")"
+env_json="$(perms_yaml_to_json    "$REPO_ROOT/templates/permissions/${env}.yaml")"
+overlay_path="$PROJECT_DIR/.omao/permissions.yaml"
+overlay_json='{}'
+overlay_present=0
+if [ -f "$overlay_path" ]; then
+    overlay_json="$(perms_yaml_to_json "$overlay_path")"
+    overlay_present=1
+fi
+
+resolved_json="$(perms_resolve_with_overlays "$env" "$PROJECT_DIR")"
+
+# Produce a per-entry provenance map: bucket -> [{pattern, source}, ...]
+# source ∈ "common.yaml" | "<env>.yaml" | "overlay" .
+prov_json="$(jq -n \
+    --argjson c "$common_json" \
+    --argjson e "$env_json" \
+    --argjson o "$overlay_json" \
+    --argjson r "$resolved_json" \
+    --arg     env "$env" \
+    '
+    def annotate(bucket):
+      ($r.deny[bucket] // []) | map(
+        . as $p
+        | {pattern: $p,
+           source:
+             (if (($c.deny // {})[bucket] // []) | index($p)
+              then "common.yaml"
+              elif (($e.deny // {})[bucket] // []) | index($p)
+              then ($env + ".yaml")
+              elif (($o.deny.add // {})[bucket] // []) | index($p)
+              then "overlay"
+              else "?" end)}
+      );
+    {
+      bash:  annotate("bash"),
+      edit:  annotate("edit"),
+      write: annotate("write"),
+      mcp:   annotate("mcp"),
+      removed: ($o.deny.remove // {}),
+      auto_approve: $r.auto_approve,
+      env: $env,
+      overlay_path: ($r._meta.overlay_path // null),
+      overlay_applied: ($r._meta.overlay_applied // false),
+      templates_chain: ($r._meta.templates // [])
+    }
+    ')"
+
+if [ "$FORMAT" = "json" ]; then
+    printf '%s\n' "$prov_json" | jq .
+    exit 0
+fi
+
+# Pretty output
+overlay_status="overlay : (none — create with: oma permissions path)"
+if [ "$overlay_present" -eq 1 ]; then
+    if [ "$(printf '%s' "$resolved_json" | jq -r '._meta.overlay_applied')" = "true" ]; then
+        overlay_status="overlay : $overlay_path (applied)"
+    else
+        overlay_status="overlay : $overlay_path (present, no rules)"
+    fi
+fi
+
+printf '\nResolved permission chain — %s\n' "$env"
+printf '=========================\n'
+printf '  env       : %s\n'   "$env"
+printf '  templates : %s\n'   "$(printf '%s' "$prov_json" | jq -r '.templates_chain | join(" + ")')"
+printf '  %s\n'                "$overlay_status"
+printf '  autoApprove.readOnly     : %s\n' "$(printf '%s' "$prov_json" | jq -r '.auto_approve.read_only')"
+printf '  autoApprove.fileWrites   : %s\n' "$(printf '%s' "$prov_json" | jq -r '.auto_approve.file_writes')"
+printf '  autoApprove.bashCommands : %s\n' "$(printf '%s' "$prov_json" | jq -r '.auto_approve.bash_commands')"
+
+for bucket in bash edit write mcp; do
+    count="$(printf '%s' "$prov_json" | jq ".${bucket} | length")"
+    printf '\n  deny.%-5s (%d):\n' "$bucket" "$count"
+    printf '%s\n' "$prov_json" | jq -r ".${bucket}[] | \"    [\\(.source | (. + \"             \")[0:13])] \\(.pattern)\""
+done
+
+removed_total="$(printf '%s' "$prov_json" | jq '[.removed[]?] | add // [] | length')"
+if [ "$removed_total" -gt 0 ]; then
+    printf '\n  overlay removals (%d):\n' "$removed_total"
+    for bucket in bash edit write mcp; do
+        count="$(printf '%s' "$prov_json" | jq ".removed.${bucket} // [] | length")"
+        if [ "$count" -gt 0 ]; then
+            printf '    %s:\n' "$bucket"
+            printf '%s\n' "$prov_json" | jq -r ".removed.${bucket}[] | \"      - \" + ."
+        fi
+    done
+fi
+printf '\n'

--- a/scripts/oma/setup.sh
+++ b/scripts/oma/setup.sh
@@ -231,6 +231,9 @@ if [ "$SKIP_INSTALL" = 1 ]; then
 elif [ "$DRY_RUN" = 1 ]; then
     ok "dry-run: would install $HARNESS_PRIMARY${HARNESS_SECONDARY:+ + $HARNESS_SECONDARY}"
 else
+    # Pass OMA_PROJECT_DIR so install_permissions can locate
+    # .omao/profile.yaml from this project, not the install script's cwd.
+    export OMA_PROJECT_DIR="$PROJECT_DIR"
     case "$HARNESS_PRIMARY" in
         claude-code) bash "$REPO_ROOT/scripts/install/claude.sh" || warn "claude install returned non-zero" ;;
         kiro)        bash "$REPO_ROOT/scripts/install/kiro.sh"   || warn "kiro install returned non-zero" ;;

--- a/scripts/oma/setup.sh
+++ b/scripts/oma/setup.sh
@@ -218,6 +218,21 @@ if [ ! -f "$OMAO_DIR/triggers.json" ] && [ -f "$REPO_ROOT/.omao/triggers.json" ]
     ok "copied triggers.json"
 fi
 
+# Seed .omao/permissions.yaml — the project-level permission overlay.
+# This file is the user-owned customization point; install_permissions()
+# layers it on top of templates/permissions/<env>.yaml.
+# Never overwrite an existing overlay (user content is preserved verbatim).
+if [ "$DRY_RUN" = 0 ]; then
+    overlay_dst="$OMAO_DIR/permissions.yaml"
+    overlay_src="$REPO_ROOT/templates/permissions/overlay.yaml.tmpl"
+    if [ -f "$overlay_dst" ]; then
+        skip "permissions overlay already present: $overlay_dst"
+    elif [ -f "$overlay_src" ]; then
+        cp "$overlay_src" "$overlay_dst"
+        ok "seeded $overlay_dst (commented start; see \`oma permissions show\`)"
+    fi
+fi
+
 # Bootstrap notepad + project-memory (reuse init-omao.sh for consistency).
 if [ "$DRY_RUN" = 0 ]; then
     PROJECT_DIR="$PROJECT_DIR" bash "$REPO_ROOT/scripts/init-omao.sh" --force --dir "$PROJECT_DIR" >/dev/null 2>&1 || true

--- a/templates/permissions/README.md
+++ b/templates/permissions/README.md
@@ -78,14 +78,30 @@ can copy a template into `.omao/permissions.yaml` and the install script
 will prefer the local copy. That override path lands with the install
 script commit.
 
-## What this commit does NOT do
+## How the templates are applied
 
-- Does not modify `scripts/install/claude.sh` or `scripts/install/kiro.sh`.
-- Does not modify any plugin's `*.oma.yaml`.
-- Does not modify `bin/oma` or any subcommand.
-- Does not write to `~/.claude/settings.json` or `~/.kiro/`.
+`scripts/lib/permissions.sh` is the shared resolver:
 
-A separate follow-up commit adds `install_permissions()` to both install
-scripts and wires it into `oma setup`. Splitting the work this way lets
-reviewers see and edit the abstract templates before any harness-specific
-emit logic is committed.
+```bash
+. scripts/lib/permissions.sh
+perms_resolve prod | perms_to_claude_deny      # -> JSON array of "Bash(...)" lines
+perms_resolve prod | perms_to_kiro_autoapprove # -> {readOnly,fileWrites,bashCommands}
+```
+
+`install_permissions()` in `scripts/install/{claude,kiro}.sh` invokes the
+resolver based on `.omao/profile.yaml` `aws.environment` (or the
+`OMA_PERMISSIONS_ENV` override) and merges the result into:
+
+- **Claude** — `~/.claude/settings.json` `permissions.deny[]` via
+  append-uniq. Existing user-authored entries are preserved verbatim.
+- **Kiro** — `~/.kiro/settings/cli.json` `autoApprove` and each
+  OMA-installed `~/.kiro/agents/*.agent.json`. The agent files are
+  rewritten from the source repo on every run (so upstream agent
+  updates flow through), but never mutated in the tracked repo. Each
+  patched copy carries `_meta.oma_permissions_env` and
+  `_meta.oma_permissions_deny` so the deny set is auditable from Kiro
+  even though Kiro itself does not enforce a permissions list.
+
+Skip the step entirely with `--skip-permissions` or
+`OMA_SKIP_PERMISSIONS=1`. Hand-edited agent.json copies (no
+`_meta.oma_permissions_env`) are refused — delete the file to re-apply.

--- a/templates/permissions/README.md
+++ b/templates/permissions/README.md
@@ -1,0 +1,91 @@
+# OMA Permission Templates
+
+Environment-scoped deny templates that constrain the tools and resources OMA
+plugins are allowed to call. Templates here are **reference data only** —
+nothing in this directory is yet wired into `oma setup` or `oma compile`. A
+follow-up commit adds an `install_permissions()` function to
+`scripts/install/{claude,kiro}.sh` that consumes these files.
+
+## Files
+
+| File | Scope | Loaded when |
+|---|---|---|
+| `common.yaml` | Baseline rules every install inherits. Audit ledger and ontology JSON paths can only be mutated through OMA tools. | Always |
+| `sandbox.yaml` | Personal accounts, dev clusters. Relaxes auto-approve for file writes; common deny still applies. | `profile.yaml` `aws.environment: sandbox` |
+| `staging.yaml` | Shared dev clusters, pre-prod accounts. Blocks cross-region Bedrock inference profiles, cluster-wide kubectl, IAM mutation. | `profile.yaml` `aws.environment: staging` |
+| `prod.yaml` | Production accounts. Read-only manifests, GitOps-only kubectl, no IAM/secret/KMS mutation, no EKS write MCP. | `profile.yaml` `aws.environment: prod` |
+
+## Schema
+
+Each template is a YAML document with this shape:
+
+```yaml
+version: 1
+extends: ["common.yaml"]            # optional, list of template names
+applies_when:                       # optional, profile match criteria
+  aws.environment: <sandbox|staging|prod>
+description: |
+  Free-form prose explaining the intent of this template.
+
+deny:
+  bash:  []   # fnmatch globs against full command lines
+  edit:  []   # POSIX globs against file paths
+  write: []   # POSIX globs (Edit + Write merged in Kiro)
+  mcp:   []   # fnmatch globs against MCP tool names
+
+auto_approve:
+  read_only: true
+  file_writes: false
+  bash_commands: false
+```
+
+`extends` is processed by deep-merging each base into the current template:
+list keys are unioned (uniqueness preserved), scalar keys are overwritten.
+
+## Mapping to harness-native config
+
+The install script translates abstract keys to each harness format. Two
+formats today, one source of truth here.
+
+| Abstract key | Claude `.claude/settings.json` | Kiro `~/.kiro/settings/cli.json` + `~/.kiro/agents/*.agent.json` |
+|---|---|---|
+| `deny.bash[i]` | `permissions.deny += "Bash(<pattern>)"` | `cli.json autoApprove.bashCommands=false` + agent.json `tools` strips Bash |
+| `deny.edit[i]` | `permissions.deny += "Edit(<glob>)"` | `cli.json autoApprove.fileWrites=false` + agent.json `tools` strips Edit |
+| `deny.write[i]` | `permissions.deny += "Write(<glob>)"` | (same as edit — Kiro merges Edit and Write) |
+| `deny.mcp[i]` | `permissions.deny += "<mcp_tool_pattern>"` | agent.json `mcpServers[*].disabled=true` or `tools` removes the entry |
+| `auto_approve.read_only` | informational hint | `cli.json autoApprove.readOnly` and agent.json `autoApprove.readOnly` |
+| `auto_approve.file_writes` | informational hint | `cli.json autoApprove.fileWrites` and agent.json `autoApprove.fileWrites` |
+| `auto_approve.bash_commands` | informational hint | `cli.json autoApprove.bashCommands` and agent.json `autoApprove.bashCommands` |
+
+Glob semantics:
+
+- `deny.bash` and `deny.mcp` use fnmatch — `*` does not cross spaces in bash
+  patterns, and matching is case-sensitive.
+- `deny.edit` and `deny.write` use POSIX globs — use `**` for recursive
+  match across directories.
+
+## Pick the right template
+
+Picked automatically from `.omao/profile.yaml`'s `aws.environment` value:
+
+```yaml
+aws:
+  environment: prod    # → templates/permissions/prod.yaml + common.yaml
+```
+
+A user who needs to override (e.g., a dev who wants prod-strength locally)
+can copy a template into `.omao/permissions.yaml` and the install script
+will prefer the local copy. That override path lands with the install
+script commit.
+
+## What this commit does NOT do
+
+- Does not modify `scripts/install/claude.sh` or `scripts/install/kiro.sh`.
+- Does not modify any plugin's `*.oma.yaml`.
+- Does not modify `bin/oma` or any subcommand.
+- Does not write to `~/.claude/settings.json` or `~/.kiro/`.
+
+A separate follow-up commit adds `install_permissions()` to both install
+scripts and wires it into `oma setup`. Splitting the work this way lets
+reviewers see and edit the abstract templates before any harness-specific
+emit logic is committed.

--- a/templates/permissions/README.md
+++ b/templates/permissions/README.md
@@ -105,3 +105,21 @@ resolver based on `.omao/profile.yaml` `aws.environment` (or the
 Skip the step entirely with `--skip-permissions` or
 `OMA_SKIP_PERMISSIONS=1`. Hand-edited agent.json copies (no
 `_meta.oma_permissions_env`) are refused — delete the file to re-apply.
+
+## Known limitations
+
+- **Env downgrade leaves stale entries on the Claude side.** Switching
+  `aws.environment` from `prod` back to `sandbox` and re-running `oma
+  setup` adds the sandbox entries but does NOT remove the prod-only
+  entries already in `~/.claude/settings.json`. The merge is
+  append-uniq, never subtractive. To clean up, delete the unwanted
+  lines from `~/.claude/settings.json` by hand (or `oma uninstall` then
+  re-install). The Kiro side rewrites each agent copy from source on
+  every run so it self-heals; only Claude is sticky.
+- **Deny rules are user-global, not project-scoped.** `oma setup`
+  writes to `~/.claude/settings.json` rather than
+  `<project>/.claude/settings.local.json`. Two projects on the same
+  machine share whichever env was last installed.
+- **`extends` is single-level.** `<env>.yaml` may extend
+  `common.yaml`, but a base template's own `extends` chain is not
+  followed. Adequate for the four-template tree shipped today.

--- a/templates/permissions/README.md
+++ b/templates/permissions/README.md
@@ -78,14 +78,57 @@ can copy a template into `.omao/permissions.yaml` and the install script
 will prefer the local copy. That override path lands with the install
 script commit.
 
+## Customizing without editing the OMA repo — overlay
+
+Don't fork or hand-edit the templates in this directory. Instead, drop a
+project overlay at **`<project>/.omao/permissions.yaml`** and the resolver
+will layer it on top of `common.yaml` + `<env>.yaml`. The overlay is the
+only file the user is expected to edit.
+
+```yaml
+# .omao/permissions.yaml — project-level customization
+version: 1
+deny:
+  remove:                                # subtract from the resolved set
+    bash:
+      - "kubectl delete ns*"             # our team uses this routinely
+  add:                                   # add project-specific extras
+    edit:
+      - "infra/secrets/**"
+auto_approve:
+  bash_commands: true                    # override the env default
+```
+
+Resolution chain (lowest → highest priority):
+
+1. `templates/permissions/common.yaml`     (OMA repo, baseline floor)
+2. `templates/permissions/<env>.yaml`      (OMA repo, environment defaults)
+3. `<project>/.omao/permissions.yaml`     (user overlay, optional)
+
+Removals are exact-match against the post-merge deny array. To remove a
+pattern that was introduced by `common.yaml` or `<env>.yaml`, copy the
+exact string into `deny.remove.<bucket>`.
+
+`oma permissions show [--json]` prints the resolved chain with provenance
+for each entry (which layer it came from, plus overlay add/remove counts).
+`oma permissions path` prints `<project>/.omao/permissions.yaml` so you
+can `$EDITOR $(oma permissions path)`.
+
+After editing the overlay, **re-run `oma setup`** (or
+`bash scripts/install/{claude,kiro}.sh`) to push the new resolved set
+into `~/.claude/settings.json` and `~/.kiro/`. The overlay file alone
+does not affect a running Claude/Kiro session — those harnesses only
+read their own home-dir config.
+
 ## How the templates are applied
 
 `scripts/lib/permissions.sh` is the shared resolver:
 
 ```bash
 . scripts/lib/permissions.sh
-perms_resolve prod | perms_to_claude_deny      # -> JSON array of "Bash(...)" lines
-perms_resolve prod | perms_to_kiro_autoapprove # -> {readOnly,fileWrites,bashCommands}
+perms_resolve prod | perms_to_claude_deny           # -> Bash/Edit/Write/MCP strings
+perms_resolve_with_overlays prod /path/to/proj      # -> chain incl. .omao overlay
+perms_to_kiro_autoapprove                            # -> {readOnly,fileWrites,…}
 ```
 
 `install_permissions()` in `scripts/install/{claude,kiro}.sh` invokes the

--- a/templates/permissions/common.yaml
+++ b/templates/permissions/common.yaml
@@ -1,0 +1,63 @@
+# OMA Permission Template — common (shared by every environment)
+#
+# This file declares the abstract deny set every OMA install applies regardless
+# of `aws.environment`. Environment-specific overlays (sandbox/staging/prod.yaml)
+# extend this file via `extends: ["common.yaml"]`.
+#
+# Why "abstract": the same rule must be emitted into two harness-specific
+# config formats. install scripts translate these keys as follows.
+#
+# | abstract key      | Claude (.claude/settings.json)              | Kiro (~/.kiro/settings/cli.json + agents/*.agent.json) |
+# | ----------------- | ------------------------------------------- | ------------------------------------------------------ |
+# | deny.bash         | permissions.deny += "Bash(<pattern>)"       | autoApprove.bashCommands=false + agents.tools strip   |
+# | deny.edit         | permissions.deny += "Edit(<glob>)"          | autoApprove.fileWrites=false + agents.tools filter    |
+# | deny.write        | permissions.deny += "Write(<glob>)"         | (same as edit — Kiro merges Edit/Write)               |
+# | deny.mcp          | permissions.deny += "<mcp_tool_pattern>"    | agents.mcpServers entry disabled or tool removed      |
+# | auto_approve.*    | permissions.defaultMode hint                | settings.cli.json autoApprove.{readOnly,fileWrites,…} |
+#
+# Patterns:
+# - `deny.bash` / `deny.mcp` — fnmatch globs against the full command line or
+#   tool name (case-sensitive). `*` does NOT cross spaces in bash patterns.
+# - `deny.edit` / `deny.write` — POSIX globs against the file path argument.
+#   Use `**` for recursive match.
+#
+# Backward compatibility: this file is reference data only. It is consumed by
+# `oma setup` / `oma compile` once the install script's `install_permissions()`
+# function lands (separate commit). Until then, dropping/editing this file has
+# no runtime effect.
+
+version: 1
+description: |
+  Baseline deny rules every OMA project inherits. Protects the audit ledger
+  and ontology entry points so they can only be mutated through OMA tools
+  (oma_audit.append, oma promote, oma backup), never by free-form Edit/Bash.
+
+# Sentinel paths that OMA owns. Direct edits would silently break the audit
+# chain or the ontology contract. The corresponding write helpers
+# (tools/oma_audit/append.py, scripts/oma/*.sh) remain the only legal entry.
+deny:
+  edit:
+    - ".omao/audit.jsonl"
+    - ".omao/ontology/**/*.json"
+    - ".omao/state/active-mode"
+  write:
+    - ".omao/audit.jsonl"
+    - ".omao/ontology/**/*.json"
+  bash:
+    # In-place audit log mutation — sed/awk -i, truncate, redirect.
+    - "sed -i*.omao/audit*"
+    - "awk -i*.omao/audit*"
+    - ":>*.omao/audit*"
+    - "*>*.omao/audit.jsonl*"      # any redirect into audit.jsonl
+    - "rm*.omao/audit.jsonl*"
+    # Ontology JSON tampering bypassing oma promote / oma_audit.append.
+    - "jq*-i*.omao/ontology/*"
+    - "rm*.omao/ontology/*.json*"
+  mcp: []   # no MCP-level deny in the common baseline
+
+# Auto-approval defaults. Environment overlays may relax (sandbox) or tighten
+# (prod), but read_only=true is a floor — we never auto-approve unread tools.
+auto_approve:
+  read_only: true
+  file_writes: false
+  bash_commands: false

--- a/templates/permissions/common.yaml
+++ b/templates/permissions/common.yaml
@@ -4,59 +4,65 @@
 # of `aws.environment`. Environment-specific overlays (sandbox/staging/prod.yaml)
 # extend this file via `extends: ["common.yaml"]`.
 #
-# Why "abstract": the same rule must be emitted into two harness-specific
-# config formats. install scripts translate these keys as follows.
+# Philosophy
+# ----------
+# These templates are about preventing *accidents*, not about sandboxing the
+# agent. The user can always remove a rule from ~/.claude/settings.json or
+# ~/.kiro/agents/<name>.agent.json if it gets in the way. A deny entry should
+# only exist when the failure mode it prevents is destructive enough that the
+# extra confirmation step is worth the friction.
 #
+# What `common.yaml` protects
+# ---------------------------
+# Just one thing: `.omao/audit.jsonl`. The audit ledger is the only OMA-owned
+# file whose corruption is silent and forensically expensive — once timestamps
+# are lost or lines are removed, downstream tooling (`oma doctor`, future hash
+# chain) can no longer prove what happened. We block the *destructive* shell
+# patterns (in-place rewrite, redirect, rm) but leave Edit/Write alone so the
+# user can still inspect or hand-fix the file when they explicitly want to.
+#
+# Format reference
+# ----------------
 # | abstract key      | Claude (.claude/settings.json)              | Kiro (~/.kiro/settings/cli.json + agents/*.agent.json) |
 # | ----------------- | ------------------------------------------- | ------------------------------------------------------ |
-# | deny.bash         | permissions.deny += "Bash(<pattern>)"       | autoApprove.bashCommands=false + agents.tools strip   |
-# | deny.edit         | permissions.deny += "Edit(<glob>)"          | autoApprove.fileWrites=false + agents.tools filter    |
-# | deny.write        | permissions.deny += "Write(<glob>)"         | (same as edit — Kiro merges Edit/Write)               |
-# | deny.mcp          | permissions.deny += "<mcp_tool_pattern>"    | agents.mcpServers entry disabled or tool removed      |
-# | auto_approve.*    | permissions.defaultMode hint                | settings.cli.json autoApprove.{readOnly,fileWrites,…} |
+# | deny.bash         | permissions.deny += "Bash(<pattern>)"       | autoApprove.bashCommands floor                         |
+# | deny.edit         | permissions.deny += "Edit(<glob>)"          | autoApprove.fileWrites floor + _meta.oma_permissions   |
+# | deny.write        | permissions.deny += "Write(<glob>)"         | (same as edit — Kiro merges Edit/Write)                |
+# | deny.mcp          | permissions.deny += "<mcp_tool_pattern>"    | _meta.oma_permissions                                  |
+# | auto_approve.*    | informational hint                          | settings.cli.json autoApprove.{readOnly,fileWrites,…}  |
 #
 # Patterns:
 # - `deny.bash` / `deny.mcp` — fnmatch globs against the full command line or
 #   tool name (case-sensitive). `*` does NOT cross spaces in bash patterns.
 # - `deny.edit` / `deny.write` — POSIX globs against the file path argument.
 #   Use `**` for recursive match.
-#
-# Backward compatibility: this file is reference data only. It is consumed by
-# `oma setup` / `oma compile` once the install script's `install_permissions()`
-# function lands (separate commit). Until then, dropping/editing this file has
-# no runtime effect.
 
 version: 1
 description: |
-  Baseline deny rules every OMA project inherits. Protects the audit ledger
-  and ontology entry points so they can only be mutated through OMA tools
-  (oma_audit.append, oma promote, oma backup), never by free-form Edit/Bash.
+  Audit-ledger guard. Blocks shell patterns that would corrupt
+  .omao/audit.jsonl in place. Everything else is left to environment
+  overlays. Edit/Write to the ledger are NOT blocked here — `oma doctor`
+  will detect tampering after the fact, and a user inspecting the file
+  with their editor is a normal workflow.
 
-# Sentinel paths that OMA owns. Direct edits would silently break the audit
-# chain or the ontology contract. The corresponding write helpers
-# (tools/oma_audit/append.py, scripts/oma/*.sh) remain the only legal entry.
 deny:
-  edit:
-    - ".omao/audit.jsonl"
-    - ".omao/ontology/**/*.json"
-    - ".omao/state/active-mode"
-  write:
-    - ".omao/audit.jsonl"
-    - ".omao/ontology/**/*.json"
   bash:
-    # In-place audit log mutation — sed/awk -i, truncate, redirect.
+    # In-place rewrite, truncate, redirect, or delete of the audit ledger.
+    # All of these would silently break the chain in ways the user cannot
+    # easily reverse, so we force the slow path (Edit it, or use the
+    # tools/oma_audit/append.py CLI).
     - "sed -i*.omao/audit*"
     - "awk -i*.omao/audit*"
     - ":>*.omao/audit*"
     - "*>*.omao/audit.jsonl*"      # any redirect into audit.jsonl
     - "rm*.omao/audit.jsonl*"
-    # Ontology JSON tampering bypassing oma promote / oma_audit.append.
-    - "jq*-i*.omao/ontology/*"
-    - "rm*.omao/ontology/*.json*"
-  mcp: []   # no MCP-level deny in the common baseline
+  edit: []
+  write: []
+  mcp:  []
 
-# Auto-approval defaults. Environment overlays may relax (sandbox) or tighten
-# (prod), but read_only=true is a floor — we never auto-approve unread tools.
+# Auto-approval defaults. Environment overlays adjust these.
+# read_only stays true everywhere — we never need user clicks for `cat`,
+# `ls`, or pure-read MCP queries.
 auto_approve:
   read_only: true
   file_writes: false

--- a/templates/permissions/overlay.yaml.tmpl
+++ b/templates/permissions/overlay.yaml.tmpl
@@ -1,0 +1,49 @@
+# .omao/permissions.yaml — project-level permission overlay
+#
+# This file lets you customize the OMA permission set without editing the
+# OMA repo. Drop rules below, then re-run `oma setup` (or
+# `bash scripts/install/{claude,kiro}.sh`) to push the change into
+# ~/.claude/settings.json and ~/.kiro/.
+#
+# Resolution chain (lowest → highest priority):
+#   1. templates/permissions/common.yaml   (OMA baseline floor)
+#   2. templates/permissions/<env>.yaml    (env defaults from profile.yaml)
+#   3. THIS FILE                           (your project-specific overrides)
+#
+# Inspect: `oma permissions show` (annotated) or
+#          `oma permissions show --json` (machine-readable).
+#
+# Edit:    `$EDITOR $(oma permissions path)`
+#
+# Apply:   `oma setup --skip-doctor` or `bash scripts/install/claude.sh`
+#
+# Every key below is OPTIONAL. The default of "no overlay" leaves the
+# template chain untouched — start by uncommenting only what your team
+# actually needs.
+
+version: 1
+
+# deny:
+#   # remove — subtract patterns from the resolved set (exact-match).
+#   # Useful when a template-level deny gets in the way of your team's flow.
+#   remove:
+#     bash:
+#       - "kubectl delete ns*"          # we use this routinely on staging
+#     edit: []
+#     write: []
+#     mcp: []
+#
+#   # add — extra patterns this project needs blocked on top of the templates.
+#   add:
+#     bash: []
+#     edit:
+#       - "infra/secrets/**"            # prevent accidental secret edits
+#     write: []
+#     mcp: []
+#
+# # auto_approve — override the env defaults. Each key is optional; an
+# # explicit value (including `false`) wins over the resolved chain.
+# auto_approve:
+#   read_only:     true
+#   file_writes:   true
+#   bash_commands: false

--- a/templates/permissions/prod.yaml
+++ b/templates/permissions/prod.yaml
@@ -1,15 +1,9 @@
 # OMA Permission Template — prod
 #
-# Tightest profile. Intended for production AWS accounts that hold real
-# customer data, run user-facing inference traffic, or are gated by
-# compliance regimes (SOC 2, ISMS-P, NIST AI RMF). Inherits common.yaml
-# audit/ontology guards and adds infrastructure mutation guards on top.
-#
-# Prod should never accept agent-driven destructive changes. The pattern is
-# always: agent prepares a Spec/ADR/Deployment, a human approves out-of-band,
-# `oma promote` materializes the change. Direct kubectl/aws/helm calls that
-# mutate infra are blocked at the harness layer so a slip in agent reasoning
-# cannot cascade into a production outage.
+# Production AWS accounts. Inherits common.yaml audit guard. The deny set
+# is intentionally narrow — only operations that are almost never the right
+# choice from an agent context. The user can still run them directly; the
+# deny just forces them out of any auto-approve flow.
 
 version: 1
 extends: ["common.yaml"]
@@ -17,88 +11,57 @@ applies_when:
   aws.environment: prod
 
 description: |
-  Production profile — agents may read freely but must not mutate infra,
-  IAM, or secret stores directly. Manifests are read-only at the harness
-  layer; changes flow through GitOps PRs. Cross-region inference profiles
-  are blocked (cost & data-residency concerns).
+  Production profile — confirmation gate on the handful of operations
+  that have caused real outages when run reflexively (cluster delete,
+  IAM detach, secret deletion, force-pushing manifests). Routine reads
+  and edits remain auto-approved; the agent stays useful in prod, just
+  not autonomous on destructive paths.
 
 deny:
   bash:
-    # Cross-region Bedrock inference profiles — prod must pin region.
+    # Cross-region Bedrock — same reason as staging, but enforced.
     - "aws bedrock-runtime invoke-model*global.anthropic*"
     - "aws bedrock-runtime invoke-model*global.amazon*"
-    # All destructive kubectl. Reads (get/describe/logs) remain allowed.
-    - "kubectl delete*"
-    - "kubectl apply*"        # apply only via GitOps controller
-    - "kubectl patch*"
-    - "kubectl rollout undo*" # rollback through `oma promote --to rolled_back`
-    - "kubectl scale*"
-    - "kubectl exec*"         # exec into prod pods bypasses audit
-    - "kubectl edit*"
-    - "kubectl cp*"
-    # Helm — prod uses ArgoCD/Flux only.
-    - "helm install*"
-    - "helm upgrade*"
+    # Cluster-wide kubectl deletes. Namespaced delete remains allowed so
+    # the agent can clean up its own resources.
+    - "kubectl delete ns*"
+    - "kubectl delete clusterrole*"
+    - "kubectl delete clusterrolebinding*"
+    - "kubectl delete crd*"
+    # Helm uninstall. Reinstalls/upgrades remain available.
     - "helm uninstall*"
-    - "helm rollback*"
-    # IAM mutation — humans only.
-    - "aws iam create-*"
+    # IAM destructive ops. Create/update remain available because they're
+    # the common path for adding least-privilege bindings.
     - "aws iam delete-*"
-    - "aws iam attach-*"
     - "aws iam detach-*"
-    - "aws iam put-*"
-    - "aws iam update-*"
-    # Secrets / KMS / parameter store — read in narrow paths only,
-    # never mutate from agent context.
-    - "aws secretsmanager put-secret-value*"
+    # Secret destruction.
     - "aws secretsmanager delete-secret*"
-    - "aws ssm put-parameter*"
-    - "aws ssm delete-parameter*"
     - "aws kms schedule-key-deletion*"
-    - "aws kms disable-key*"
-    # S3 bucket-level destructive ops.
+    # ECR repository delete. Single-image delete remains.
+    - "aws ecr delete-repository*"
+    # S3 bucket-level delete.
     - "aws s3 rb*"
     - "aws s3api delete-bucket*"
-    - "aws s3api put-bucket-policy*"
-    # ECR delete — prod images are immutable.
-    - "aws ecr batch-delete-image*"
-    - "aws ecr delete-repository*"
   edit:
-    # Manifests are GitOps-owned. PR flow only.
-    - "manifests/**"
-    - "charts/**"
-    - "kustomize/**"
-    # AWS / SSH / kube credentials.
+    # Local credentials and SSH/kube config — never edit from agent context.
     - "/Users/**/.aws/credentials"
-    - "/Users/**/.aws/config"
     - "/Users/**/.ssh/**"
     - "/Users/**/.kube/**"
     # System paths.
     - "/etc/**"
-    - "/usr/local/**"
   write:
-    - "manifests/**"
-    - "charts/**"
-    - "kustomize/**"
     - "/Users/**/.aws/credentials"
-    - "/Users/**/.aws/config"
     - "/Users/**/.ssh/**"
     - "/Users/**/.kube/**"
     - "/etc/**"
   mcp:
-    # EKS write ops disabled — prod EKS goes through CodePipeline, not agents.
-    - "mcp__eks__*create*"
-    - "mcp__eks__*update*"
+    # The single MCP class that historically caused prod outages: cluster
+    # deletion via the EKS MCP server. Other EKS write ops (update node
+    # group, scale, etc.) remain available so the agent can still help
+    # with operations work.
     - "mcp__eks__*delete*"
-    - "mcp__eks__*put*"
-    # Bedrock KB mutations.
-    - "mcp__bedrock-kb-retrieval__*ingest*"
-    - "mcp__bedrock-kb-retrieval__*delete*"
-    # CloudWatch alarm mutation — alarms govern paging, change via Terraform.
-    - "mcp__cloudwatch__*put*"
-    - "mcp__cloudwatch__*delete*"
 
 auto_approve:
   read_only: true
-  file_writes: false
+  file_writes: true
   bash_commands: false

--- a/templates/permissions/prod.yaml
+++ b/templates/permissions/prod.yaml
@@ -1,0 +1,104 @@
+# OMA Permission Template — prod
+#
+# Tightest profile. Intended for production AWS accounts that hold real
+# customer data, run user-facing inference traffic, or are gated by
+# compliance regimes (SOC 2, ISMS-P, NIST AI RMF). Inherits common.yaml
+# audit/ontology guards and adds infrastructure mutation guards on top.
+#
+# Prod should never accept agent-driven destructive changes. The pattern is
+# always: agent prepares a Spec/ADR/Deployment, a human approves out-of-band,
+# `oma promote` materializes the change. Direct kubectl/aws/helm calls that
+# mutate infra are blocked at the harness layer so a slip in agent reasoning
+# cannot cascade into a production outage.
+
+version: 1
+extends: ["common.yaml"]
+applies_when:
+  aws.environment: prod
+
+description: |
+  Production profile — agents may read freely but must not mutate infra,
+  IAM, or secret stores directly. Manifests are read-only at the harness
+  layer; changes flow through GitOps PRs. Cross-region inference profiles
+  are blocked (cost & data-residency concerns).
+
+deny:
+  bash:
+    # Cross-region Bedrock inference profiles — prod must pin region.
+    - "aws bedrock-runtime invoke-model*global.anthropic*"
+    - "aws bedrock-runtime invoke-model*global.amazon*"
+    # All destructive kubectl. Reads (get/describe/logs) remain allowed.
+    - "kubectl delete*"
+    - "kubectl apply*"        # apply only via GitOps controller
+    - "kubectl patch*"
+    - "kubectl rollout undo*" # rollback through `oma promote --to rolled_back`
+    - "kubectl scale*"
+    - "kubectl exec*"         # exec into prod pods bypasses audit
+    - "kubectl edit*"
+    - "kubectl cp*"
+    # Helm — prod uses ArgoCD/Flux only.
+    - "helm install*"
+    - "helm upgrade*"
+    - "helm uninstall*"
+    - "helm rollback*"
+    # IAM mutation — humans only.
+    - "aws iam create-*"
+    - "aws iam delete-*"
+    - "aws iam attach-*"
+    - "aws iam detach-*"
+    - "aws iam put-*"
+    - "aws iam update-*"
+    # Secrets / KMS / parameter store — read in narrow paths only,
+    # never mutate from agent context.
+    - "aws secretsmanager put-secret-value*"
+    - "aws secretsmanager delete-secret*"
+    - "aws ssm put-parameter*"
+    - "aws ssm delete-parameter*"
+    - "aws kms schedule-key-deletion*"
+    - "aws kms disable-key*"
+    # S3 bucket-level destructive ops.
+    - "aws s3 rb*"
+    - "aws s3api delete-bucket*"
+    - "aws s3api put-bucket-policy*"
+    # ECR delete — prod images are immutable.
+    - "aws ecr batch-delete-image*"
+    - "aws ecr delete-repository*"
+  edit:
+    # Manifests are GitOps-owned. PR flow only.
+    - "manifests/**"
+    - "charts/**"
+    - "kustomize/**"
+    # AWS / SSH / kube credentials.
+    - "/Users/**/.aws/credentials"
+    - "/Users/**/.aws/config"
+    - "/Users/**/.ssh/**"
+    - "/Users/**/.kube/**"
+    # System paths.
+    - "/etc/**"
+    - "/usr/local/**"
+  write:
+    - "manifests/**"
+    - "charts/**"
+    - "kustomize/**"
+    - "/Users/**/.aws/credentials"
+    - "/Users/**/.aws/config"
+    - "/Users/**/.ssh/**"
+    - "/Users/**/.kube/**"
+    - "/etc/**"
+  mcp:
+    # EKS write ops disabled — prod EKS goes through CodePipeline, not agents.
+    - "mcp__eks__*create*"
+    - "mcp__eks__*update*"
+    - "mcp__eks__*delete*"
+    - "mcp__eks__*put*"
+    # Bedrock KB mutations.
+    - "mcp__bedrock-kb-retrieval__*ingest*"
+    - "mcp__bedrock-kb-retrieval__*delete*"
+    # CloudWatch alarm mutation — alarms govern paging, change via Terraform.
+    - "mcp__cloudwatch__*put*"
+    - "mcp__cloudwatch__*delete*"
+
+auto_approve:
+  read_only: true
+  file_writes: false
+  bash_commands: false

--- a/templates/permissions/sandbox.yaml
+++ b/templates/permissions/sandbox.yaml
@@ -1,0 +1,31 @@
+# OMA Permission Template — sandbox
+#
+# Loosest profile. Intended for personal AWS accounts, dev clusters, and the
+# sandbox environment used by `harness-proposal-2026-05-08` / ai-on-eks demo
+# stacks. The common.yaml baseline still applies — sandbox only relaxes the
+# auto_approve defaults; it does NOT remove any common deny rule.
+
+version: 1
+extends: ["common.yaml"]
+applies_when:
+  aws.environment: sandbox
+
+description: |
+  Sandbox profile — assumes the AWS account is isolated, has no production
+  data, and that the user wants minimal friction. Common.yaml audit/ontology
+  guards are inherited unchanged so even sandbox runs cannot tamper with the
+  OMA ledger.
+
+deny:
+  bash: []
+  edit: []
+  write: []
+  mcp: []
+
+# Sandbox: convenience wins over rigour.
+auto_approve:
+  read_only: true
+  file_writes: true       # Edit/Write auto-approved; common.yaml still blocks
+                          # the audit ledger and ontology paths.
+  bash_commands: false    # bash stays gated — sandbox accidents on the host
+                          # FS (rm, kubectl) are still costly.

--- a/templates/permissions/sandbox.yaml
+++ b/templates/permissions/sandbox.yaml
@@ -1,9 +1,8 @@
 # OMA Permission Template — sandbox
 #
-# Loosest profile. Intended for personal AWS accounts, dev clusters, and the
-# sandbox environment used by `harness-proposal-2026-05-08` / ai-on-eks demo
-# stacks. The common.yaml baseline still applies — sandbox only relaxes the
-# auto_approve defaults; it does NOT remove any common deny rule.
+# Loosest profile. Personal AWS accounts, dev clusters, the sandbox env used
+# by ai-on-eks demo stacks. Auto-approves both file writes and bash so the
+# agent can iterate quickly. The common.yaml audit-ledger guard still applies.
 
 version: 1
 extends: ["common.yaml"]
@@ -11,21 +10,18 @@ applies_when:
   aws.environment: sandbox
 
 description: |
-  Sandbox profile — assumes the AWS account is isolated, has no production
-  data, and that the user wants minimal friction. Common.yaml audit/ontology
-  guards are inherited unchanged so even sandbox runs cannot tamper with the
-  OMA ledger.
+  Sandbox profile — minimal friction. Only the audit ledger destructive
+  patterns from common.yaml are blocked. File writes and bash commands
+  auto-approve so the agent can run end-to-end without confirmation
+  prompts at every step.
 
 deny:
-  bash: []
-  edit: []
+  bash:  []
+  edit:  []
   write: []
-  mcp: []
+  mcp:   []
 
-# Sandbox: convenience wins over rigour.
 auto_approve:
   read_only: true
-  file_writes: true       # Edit/Write auto-approved; common.yaml still blocks
-                          # the audit ledger and ontology paths.
-  bash_commands: false    # bash stays gated — sandbox accidents on the host
-                          # FS (rm, kubectl) are still costly.
+  file_writes: true
+  bash_commands: true

--- a/templates/permissions/staging.yaml
+++ b/templates/permissions/staging.yaml
@@ -1,9 +1,13 @@
 # OMA Permission Template — staging
 #
-# Mid-strength profile. Intended for shared dev clusters, pre-prod accounts,
-# and any environment that holds non-production but real data (synthetic
-# customer records, integration test fixtures, real Bedrock spend). Inherits
-# common.yaml audit/ontology guards.
+# Mid-strength profile. Shared dev clusters, pre-prod accounts, environments
+# that hold non-production but real data. Inherits common.yaml audit guard.
+#
+# Staging blocks only the operations whose accidental execution would either
+# (a) cost the team noticeable money on a wrong region, or (b) overwrite the
+# user's local credentials. Everything else (kubectl, helm, IAM read/write
+# inside the user's own role) stays available — staging is where the team
+# rehearses the prod path.
 
 version: 1
 extends: ["common.yaml"]
@@ -11,43 +15,28 @@ applies_when:
   aws.environment: staging
 
 description: |
-  Staging profile — assumes shared resources and real spend. Cross-region
-  Bedrock inference profiles and destructive kubectl/aws calls are blocked
-  to prevent accidental fan-out. Manifests stay editable (staging is where
-  GitOps PRs are dry-run before prod promotion).
+  Staging profile — guards cross-region Bedrock inference profiles
+  (cost surprise risk) and the user's local AWS/SSH credentials.
+  Bash auto-approve disabled so destructive ad-hoc commands at least
+  surface a confirmation. File writes auto-approve to keep manifest
+  iteration smooth.
 
 deny:
   bash:
-    # Cross-region Bedrock inference profiles — staging should pin a region
-    # explicitly via `aws bedrock-runtime invoke-model --region` rather than
-    # relying on `global.*` profiles that span regions silently.
+    # `global.*` Bedrock inference profiles span regions. Staging should pin
+    # the region explicitly so spend stays in the expected billing bucket.
     - "aws bedrock-runtime invoke-model*global.anthropic*"
     - "aws bedrock-runtime invoke-model*global.amazon*"
-    # Cluster-wide destructive kubectl. Namespaced delete remains allowed.
-    - "kubectl delete ns*"
-    - "kubectl delete clusterrole*"
-    - "kubectl delete clusterrolebinding*"
-    - "kubectl delete crd*"
-    # Helm uninstall — explicit `oma promote --to rolled_back` is the path.
-    - "helm uninstall*"
-    # IAM destructive actions — staging IAM is shared, treat as prod-adjacent.
-    - "aws iam delete-*"
-    - "aws iam detach-*"
   edit:
-    # AWS credentials & SSH keys — never edit from agent context.
+    # Local credential and key material — never edit from agent context.
     - "/Users/**/.aws/credentials"
-    - "/Users/**/.aws/config"
     - "/Users/**/.ssh/**"
   write:
     - "/Users/**/.aws/credentials"
-    - "/Users/**/.aws/config"
     - "/Users/**/.ssh/**"
-  mcp:
-    # KB writes are deferred until prod hardening. Read-only KB queries OK.
-    - "mcp__bedrock-kb-retrieval__*ingest*"
-    - "mcp__bedrock-kb-retrieval__*delete*"
+  mcp: []
 
 auto_approve:
   read_only: true
-  file_writes: false       # require explicit user click on every write
+  file_writes: true
   bash_commands: false

--- a/templates/permissions/staging.yaml
+++ b/templates/permissions/staging.yaml
@@ -1,0 +1,53 @@
+# OMA Permission Template — staging
+#
+# Mid-strength profile. Intended for shared dev clusters, pre-prod accounts,
+# and any environment that holds non-production but real data (synthetic
+# customer records, integration test fixtures, real Bedrock spend). Inherits
+# common.yaml audit/ontology guards.
+
+version: 1
+extends: ["common.yaml"]
+applies_when:
+  aws.environment: staging
+
+description: |
+  Staging profile — assumes shared resources and real spend. Cross-region
+  Bedrock inference profiles and destructive kubectl/aws calls are blocked
+  to prevent accidental fan-out. Manifests stay editable (staging is where
+  GitOps PRs are dry-run before prod promotion).
+
+deny:
+  bash:
+    # Cross-region Bedrock inference profiles — staging should pin a region
+    # explicitly via `aws bedrock-runtime invoke-model --region` rather than
+    # relying on `global.*` profiles that span regions silently.
+    - "aws bedrock-runtime invoke-model*global.anthropic*"
+    - "aws bedrock-runtime invoke-model*global.amazon*"
+    # Cluster-wide destructive kubectl. Namespaced delete remains allowed.
+    - "kubectl delete ns*"
+    - "kubectl delete clusterrole*"
+    - "kubectl delete clusterrolebinding*"
+    - "kubectl delete crd*"
+    # Helm uninstall — explicit `oma promote --to rolled_back` is the path.
+    - "helm uninstall*"
+    # IAM destructive actions — staging IAM is shared, treat as prod-adjacent.
+    - "aws iam delete-*"
+    - "aws iam detach-*"
+  edit:
+    # AWS credentials & SSH keys — never edit from agent context.
+    - "/Users/**/.aws/credentials"
+    - "/Users/**/.aws/config"
+    - "/Users/**/.ssh/**"
+  write:
+    - "/Users/**/.aws/credentials"
+    - "/Users/**/.aws/config"
+    - "/Users/**/.ssh/**"
+  mcp:
+    # KB writes are deferred until prod hardening. Read-only KB queries OK.
+    - "mcp__bedrock-kb-retrieval__*ingest*"
+    - "mcp__bedrock-kb-retrieval__*delete*"
+
+auto_approve:
+  read_only: true
+  file_writes: false       # require explicit user click on every write
+  bash_commands: false

--- a/tests/hooks/test_session_start.bats
+++ b/tests/hooks/test_session_start.bats
@@ -78,7 +78,7 @@ teardown() {
     echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
 }
 
-@test "session-start emits OMA_PERMISSIONS_DRIFT when overlay newer than settings.json" {
+@test "session-start emits OMA_PERMISSIONS_DRIFT when overlay newer than sentinel" {
     cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
 version: 1
 deny:
@@ -87,9 +87,9 @@ deny:
 YAML
     fake_home=$(mktemp -d)
     mkdir -p "$fake_home/.claude"
-    : > "$fake_home/.claude/settings.json"
-    # Backdate the harness config so the overlay is "newer".
-    touch -t 202401010000 "$fake_home/.claude/settings.json"
+    : > "$fake_home/.claude/.oma-permissions-applied-at"
+    # Backdate the OMA sentinel so the overlay is "newer".
+    touch -t 202401010000 "$fake_home/.claude/.oma-permissions-applied-at"
 
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
@@ -99,14 +99,14 @@ YAML
     rm -rf "$fake_home"
 }
 
-@test "no drift line when settings.json is newer than overlay" {
+@test "no drift line when sentinel is newer than overlay" {
     cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
 version: 1
 YAML
     touch -t 202401010000 "$PROJECT/.omao/permissions.yaml"
     fake_home=$(mktemp -d)
     mkdir -p "$fake_home/.claude"
-    : > "$fake_home/.claude/settings.json"   # current mtime, newer
+    : > "$fake_home/.claude/.oma-permissions-applied-at"   # current mtime, newer
 
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
@@ -122,8 +122,8 @@ version: 1
 YAML
     fake_home=$(mktemp -d)
     mkdir -p "$fake_home/.claude"
-    : > "$fake_home/.claude/settings.json"
-    touch -t 202401010000 "$fake_home/.claude/settings.json"
+    : > "$fake_home/.claude/.oma-permissions-applied-at"
+    touch -t 202401010000 "$fake_home/.claude/.oma-permissions-applied-at"
 
     cd "$PROJECT"
     HOME="$fake_home" OMA_DISABLE_PERMISSIONS_DRIFT=1 run bash "$HOOK"
@@ -133,15 +133,36 @@ YAML
     rm -rf "$fake_home"
 }
 
-@test "no harness config: drift detection silently skips" {
+@test "no sentinel: drift detection silently skips (never installed)" {
     cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
 version: 1
 YAML
-    fake_home=$(mktemp -d)   # no .claude or .kiro
+    fake_home=$(mktemp -d)   # no sentinel — install never ran
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
     [ "$status" -eq 0 ]
     run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    [ "$status" -eq 0 ]
+    rm -rf "$fake_home"
+}
+
+@test "kiro sentinel absent: only claude drift surfaces" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    fake_home=$(mktemp -d)
+    # Only Claude sentinel exists, with stale mtime → claude drift expected.
+    # No Kiro sentinel → must NOT mention kiro path.
+    mkdir -p "$fake_home/.claude"
+    : > "$fake_home/.claude/.oma-permissions-applied-at"
+    touch -t 202401010000 "$fake_home/.claude/.oma-permissions-applied-at"
+
+    cd "$PROJECT"
+    HOME="$fake_home" run bash "$HOOK"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+    # Drift body must NOT reference the kiro sentinel path.
+    run jq -e '.additionalContext | contains(".kiro/.oma-permissions-applied-at") | not' <<<"$output"
     [ "$status" -eq 0 ]
     rm -rf "$fake_home"
 }

--- a/tests/hooks/test_session_start.bats
+++ b/tests/hooks/test_session_start.bats
@@ -94,8 +94,8 @@ YAML
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
-    echo "$output" | jq -e '.additionalContext | contains("oma setup --skip-doctor")'
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("oma setup --skip-doctor")'
     rm -rf "$fake_home"
 }
 
@@ -111,7 +111,7 @@ YAML
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
     [ "$status" -eq 0 ]
-    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
     [ "$status" -eq 0 ]
     rm -rf "$fake_home"
 }
@@ -128,7 +128,7 @@ YAML
     cd "$PROJECT"
     HOME="$fake_home" OMA_DISABLE_PERMISSIONS_DRIFT=1 run bash "$HOOK"
     [ "$status" -eq 0 ]
-    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
     [ "$status" -eq 0 ]
     rm -rf "$fake_home"
 }
@@ -141,7 +141,7 @@ YAML
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
     [ "$status" -eq 0 ]
-    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
     [ "$status" -eq 0 ]
     rm -rf "$fake_home"
 }
@@ -160,9 +160,9 @@ YAML
     cd "$PROJECT"
     HOME="$fake_home" run bash "$HOOK"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
     # Drift body must NOT reference the kiro sentinel path.
-    run jq -e '.additionalContext | contains(".kiro/.oma-permissions-applied-at") | not' <<<"$output"
+    run jq -e '.hookSpecificOutput.additionalContext | contains(".kiro/.oma-permissions-applied-at") | not' <<<"$output"
     [ "$status" -eq 0 ]
     rm -rf "$fake_home"
 }

--- a/tests/hooks/test_session_start.bats
+++ b/tests/hooks/test_session_start.bats
@@ -77,3 +77,71 @@ teardown() {
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
 }
+
+@test "session-start emits OMA_PERMISSIONS_DRIFT when overlay newer than settings.json" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+deny:
+  add:
+    bash: ["test-pattern"]
+YAML
+    fake_home=$(mktemp -d)
+    mkdir -p "$fake_home/.claude"
+    : > "$fake_home/.claude/settings.json"
+    # Backdate the harness config so the overlay is "newer".
+    touch -t 202401010000 "$fake_home/.claude/settings.json"
+
+    cd "$PROJECT"
+    HOME="$fake_home" run bash "$HOOK"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+    echo "$output" | jq -e '.additionalContext | contains("oma setup --skip-doctor")'
+    rm -rf "$fake_home"
+}
+
+@test "no drift line when settings.json is newer than overlay" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    touch -t 202401010000 "$PROJECT/.omao/permissions.yaml"
+    fake_home=$(mktemp -d)
+    mkdir -p "$fake_home/.claude"
+    : > "$fake_home/.claude/settings.json"   # current mtime, newer
+
+    cd "$PROJECT"
+    HOME="$fake_home" run bash "$HOOK"
+    [ "$status" -eq 0 ]
+    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    [ "$status" -eq 0 ]
+    rm -rf "$fake_home"
+}
+
+@test "OMA_DISABLE_PERMISSIONS_DRIFT suppresses the drift line" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    fake_home=$(mktemp -d)
+    mkdir -p "$fake_home/.claude"
+    : > "$fake_home/.claude/settings.json"
+    touch -t 202401010000 "$fake_home/.claude/settings.json"
+
+    cd "$PROJECT"
+    HOME="$fake_home" OMA_DISABLE_PERMISSIONS_DRIFT=1 run bash "$HOOK"
+    [ "$status" -eq 0 ]
+    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    [ "$status" -eq 0 ]
+    rm -rf "$fake_home"
+}
+
+@test "no harness config: drift detection silently skips" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    fake_home=$(mktemp -d)   # no .claude or .kiro
+    cd "$PROJECT"
+    HOME="$fake_home" run bash "$HOOK"
+    [ "$status" -eq 0 ]
+    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    [ "$status" -eq 0 ]
+    rm -rf "$fake_home"
+}

--- a/tests/hooks/test_user_prompt_submit_drift.bats
+++ b/tests/hooks/test_user_prompt_submit_drift.bats
@@ -17,8 +17,10 @@ setup() {
 JSON
     FAKE_HOME="$(mktemp -d)"
     mkdir -p "$FAKE_HOME/.claude"
-    : > "$FAKE_HOME/.claude/settings.json"
-    touch -t 202401010000 "$FAKE_HOME/.claude/settings.json"
+    # Stale OMA sentinel — install ran a long time ago so any newly-touched
+    # overlay below will look "newer".
+    : > "$FAKE_HOME/.claude/.oma-permissions-applied-at"
+    touch -t 202401010000 "$FAKE_HOME/.claude/.oma-permissions-applied-at"
 }
 
 teardown() {
@@ -43,12 +45,12 @@ YAML
     echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
 }
 
-@test "no drift line when settings.json is newer than overlay" {
+@test "no drift line when sentinel is newer than overlay" {
     cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
 version: 1
 YAML
     touch -t 202401010000 "$PROJECT/.omao/permissions.yaml"
-    : > "$FAKE_HOME/.claude/settings.json"   # current mtime, newer
+    : > "$FAKE_HOME/.claude/.oma-permissions-applied-at"   # current mtime, newer
 
     run_hook 'just a normal question'
     [ "$status" -eq 0 ]

--- a/tests/hooks/test_user_prompt_submit_drift.bats
+++ b/tests/hooks/test_user_prompt_submit_drift.bats
@@ -42,7 +42,7 @@ deny:
 YAML
     run_hook 'just a normal question'
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
 }
 
 @test "no drift line when sentinel is newer than overlay" {
@@ -55,7 +55,7 @@ YAML
     run_hook 'just a normal question'
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
-        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
         [ "$status" -eq 0 ]
     fi
 }
@@ -68,7 +68,7 @@ YAML
     HOME="$FAKE_HOME" OMA_DISABLE_PERMISSIONS_DRIFT=1 run bash -c "echo 'q' | bash '$HOOK'"
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
-        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
         [ "$status" -eq 0 ]
     fi
 }
@@ -88,8 +88,8 @@ YAML
     run_hook 'launch agenticops now'
     [ "$status" -eq 0 ]
     # Trigger keyword wins: OMA_TRIGGER, not the drift keyword.
-    echo "$output" | jq -e '.additionalContext | contains("OMA_TRIGGER")'
-    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("OMA_TRIGGER")'
+    run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
     [ "$status" -eq 0 ]
 }
 
@@ -99,7 +99,7 @@ YAML
     [ "$status" -eq 0 ]
     # Either empty output or no drift mention.
     if [ -n "$output" ]; then
-        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        run jq -e '.hookSpecificOutput.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
         [ "$status" -eq 0 ]
     fi
 }

--- a/tests/hooks/test_user_prompt_submit_drift.bats
+++ b/tests/hooks/test_user_prompt_submit_drift.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# tests/hooks/test_user_prompt_submit_drift.bats
+# Coverage for the new permission-overlay drift detection in
+# hooks/user-prompt-submit.sh. The drift check runs only when no trigger
+# keyword matched and no budget warning fired — so triggers still take
+# precedence over the drift reminder.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK="$REPO_ROOT/hooks/user-prompt-submit.sh"
+    PROJECT="$(mktemp -d)"
+    mkdir -p "$PROJECT/.omao"
+    # Minimal triggers.json — no keywords, so trigger detection won't fire
+    # and the drift block becomes reachable on a plain prompt.
+    cat > "$PROJECT/.omao/triggers.json" <<'JSON'
+{ "triggers": [] }
+JSON
+    FAKE_HOME="$(mktemp -d)"
+    mkdir -p "$FAKE_HOME/.claude"
+    : > "$FAKE_HOME/.claude/settings.json"
+    touch -t 202401010000 "$FAKE_HOME/.claude/settings.json"
+}
+
+teardown() {
+    rm -rf "$PROJECT" "$FAKE_HOME"
+}
+
+# Run the hook with a plain prompt, env stubbed so drift can fire.
+run_hook() {
+    cd "$PROJECT"
+    HOME="$FAKE_HOME" run bash -c "echo '$1' | bash '$HOOK'"
+}
+
+@test "drift line surfaces on every prompt while overlay is newer than settings" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+deny:
+  add:
+    bash: ["test-pattern"]
+YAML
+    run_hook 'just a normal question'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT")'
+}
+
+@test "no drift line when settings.json is newer than overlay" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    touch -t 202401010000 "$PROJECT/.omao/permissions.yaml"
+    : > "$FAKE_HOME/.claude/settings.json"   # current mtime, newer
+
+    run_hook 'just a normal question'
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+@test "OMA_DISABLE_PERMISSIONS_DRIFT suppresses on prompt-submit" {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    cd "$PROJECT"
+    HOME="$FAKE_HOME" OMA_DISABLE_PERMISSIONS_DRIFT=1 run bash -c "echo 'q' | bash '$HOOK'"
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+@test "trigger keyword takes precedence over drift" {
+    # Re-author triggers.json so a keyword exists.
+    cat > "$PROJECT/.omao/triggers.json" <<'JSON'
+{
+  "triggers": [
+    {"id": "ag", "keywords": ["agenticops"], "context_required": [], "command": "/oma:agenticops", "description": "ops mode"}
+  ]
+}
+JSON
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+YAML
+    run_hook 'launch agenticops now'
+    [ "$status" -eq 0 ]
+    # Trigger keyword wins: OMA_TRIGGER, not the drift keyword.
+    echo "$output" | jq -e '.additionalContext | contains("OMA_TRIGGER")'
+    run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "no overlay file: hook is silent" {
+    # Overlay doesn't exist — drift block must skip cleanly.
+    run_hook 'plain prompt'
+    [ "$status" -eq 0 ]
+    # Either empty output or no drift mention.
+    if [ -n "$output" ]; then
+        run jq -e '.additionalContext | contains("OMA_PERMISSIONS_DRIFT") | not' <<<"$output"
+        [ "$status" -eq 0 ]
+    fi
+}

--- a/tests/installer/test_doctor_permissions.bats
+++ b/tests/installer/test_doctor_permissions.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# tests/installer/test_doctor_permissions.bats
+# Coverage for the `permissions-applied` probe in scripts/oma/doctor.sh.
+#
+# The probe runs against ~/.claude/settings.json and ~/.kiro/agents/. Every
+# test below points HOME at a scratch directory and uses a mocked profile so
+# we never touch the user's real install.
+#
+# We exercise the probe function directly (sourced into a probe harness) so
+# the test suite stays robust against unrelated baseline failures elsewhere
+# in doctor.sh (e.g. profile_validate dep handling).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DOCTOR="$REPO_ROOT/scripts/oma/doctor.sh"
+    CLAUDE_INSTALL="$REPO_ROOT/scripts/install/claude.sh"
+    KIRO_INSTALL="$REPO_ROOT/scripts/install/kiro.sh"
+    SANDBOX_DIR="$(mktemp -d)"
+    PROJECT="$SANDBOX_DIR/proj"
+    mkdir -p "$PROJECT/.omao"
+    export HOME="$SANDBOX_DIR/home"
+    export CLAUDE_HOME="$HOME/.claude"
+    export KIRO_HOME="$HOME/.kiro"
+    export OMA_PROJECT_DIR="$PROJECT"
+    mkdir -p "$HOME"
+    export NO_COLOR=1 OMA_QUIET=1
+}
+
+teardown() {
+    rm -rf "$SANDBOX_DIR"
+}
+
+write_profile() {
+    env="$1"
+    cat > "$PROJECT/.omao/profile.yaml" <<YAML
+version: 1
+created_at: "2026-05-09T00:00:00Z"
+harness: { primary: claude-code, secondary: null }
+aws:
+  account_id: "123456789012"
+  region: ap-northeast-2
+  profile_name: default
+  environment: $env
+aidlc: { entry_phase: inception, strict_gates: false }
+approval: { mode: interactive, blast_radius_ceiling: single-account }
+budgets: { default_monthly_usd: 200, warn_at_pct: 80, block_at_pct: 100 }
+observability: { mode: langfuse-managed, endpoint: null }
+YAML
+}
+
+# Run probe_permissions_applied in isolation. Captures the last probe entry
+# as $STATUS / $MESSAGE / $REMEDIATION for assertions.
+run_probe() {
+    bash -c '
+        set +e
+        REPO_ROOT="'"$REPO_ROOT"'"
+        PROJECT_DIR="'"$PROJECT"'"
+        . "$REPO_ROOT/scripts/lib/log.sh"
+        PROBE_IDS=(); PROBE_LABELS=(); PROBE_STATUSES=(); PROBE_MESSAGES=(); PROBE_REMEDIATIONS=()
+        record() {
+            PROBE_IDS+=("$1"); PROBE_LABELS+=("$2"); PROBE_STATUSES+=("$3")
+            PROBE_MESSAGES+=("$4"); PROBE_REMEDIATIONS+=("${5:-}")
+        }
+        eval "$(awk "/^probe_permissions_applied\\(\\)/,/^}$/" "$REPO_ROOT/scripts/oma/doctor.sh")"
+        probe_permissions_applied
+        printf "STATUS=%s\nMESSAGE=%s\nREMEDIATION=%s\n" \
+            "${PROBE_STATUSES[-1]}" "${PROBE_MESSAGES[-1]}" "${PROBE_REMEDIATIONS[-1]}"
+    '
+}
+
+@test "permissions-applied skips when no profile.yaml exists" {
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=skip$'
+    echo "$out" | grep -q 'no profile yet'
+}
+
+@test "permissions-applied skips when neither harness is installed" {
+    write_profile sandbox
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=skip$'
+    echo "$out" | grep -q 'no Claude or Kiro install detected'
+}
+
+@test "permissions-applied passes after a clean Claude install" {
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=pass$'
+    echo "$out" | grep -q 'env=sandbox'
+    echo "$out" | grep -q 'claude'
+}
+
+@test "permissions-applied passes after a clean Kiro install" {
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=pass$'
+    echo "$out" | grep -q 'env=prod'
+    echo "$out" | grep -q 'kiro'
+}
+
+@test "permissions-applied warns when Claude deny list is truncated" {
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    # Drop everything except the first deny entry.
+    tmp=$(mktemp)
+    jq '.permissions.deny = [.permissions.deny[0]]' "$CLAUDE_HOME/settings.json" > "$tmp"
+    mv "$tmp" "$CLAUDE_HOME/settings.json"
+
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=warn$'
+    echo "$out" | grep -q 'claude: [0-9]\+ missing deny entries'
+    echo "$out" | grep -q 'REMEDIATION=Re-run'
+}
+
+@test "permissions-applied warns when profile env diverges from installed Kiro tag" {
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    bash "$KIRO_INSTALL"   >/dev/null 2>&1
+    # Switch the profile to prod without re-running install — the agent.json
+    # _meta tag still says sandbox.
+    sed -i.bak 's/environment: sandbox/environment: prod/' "$PROJECT/.omao/profile.yaml"
+    rm -f "$PROJECT/.omao/profile.yaml.bak"
+
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=warn$'
+    echo "$out" | grep -q 'env=prod'
+    echo "$out" | grep -q 'kiro: 1 env-mismatch'
+}
+
+@test "permissions-applied warns when profile.yaml lacks aws.environment" {
+    cat > "$PROJECT/.omao/profile.yaml" <<'YAML'
+version: 1
+created_at: "2026-05-09T00:00:00Z"
+harness: { primary: claude-code, secondary: null }
+aws: { account_id: "123456789012", region: ap-northeast-2, profile_name: default }
+aidlc: { entry_phase: inception }
+approval: { mode: interactive }
+budgets: { default_monthly_usd: 200, warn_at_pct: 80, block_at_pct: 100 }
+observability: { mode: none, endpoint: null }
+YAML
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=warn$'
+    echo "$out" | grep -q 'missing aws.environment'
+}
+
+@test "permissions-applied warns on unsupported aws.environment" {
+    write_profile staging        # write a valid profile first
+    sed -i.bak 's/environment: staging/environment: nope/' "$PROJECT/.omao/profile.yaml"
+    rm -f "$PROJECT/.omao/profile.yaml.bak"
+
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=warn$'
+    echo "$out" | grep -q 'unsupported aws.environment: nope'
+}
+
+@test "permissions-applied passes after both Claude and Kiro installs" {
+    write_profile prod
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    bash "$KIRO_INSTALL"   >/dev/null 2>&1
+    out=$(run_probe)
+    echo "$out" | grep -q '^STATUS=pass$'
+    echo "$out" | grep -q 'env=prod'
+    echo "$out" | grep -q 'claude'
+    echo "$out" | grep -q 'kiro'
+}

--- a/tests/installer/test_install_permissions.bats
+++ b/tests/installer/test_install_permissions.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+# tests/installer/test_install_permissions.bats
+# End-to-end coverage for install_permissions() in scripts/install/{claude,kiro}.sh.
+# Each test runs the real install script against an isolated CLAUDE_HOME /
+# KIRO_HOME and a mocked .omao/profile.yaml so nothing in the user's actual
+# config is touched.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    CLAUDE_INSTALL="$REPO_ROOT/scripts/install/claude.sh"
+    KIRO_INSTALL="$REPO_ROOT/scripts/install/kiro.sh"
+    SANDBOX_DIR="$(mktemp -d)"
+    PROJECT="$SANDBOX_DIR/proj"
+    mkdir -p "$PROJECT/.omao"
+    export CLAUDE_HOME="$SANDBOX_DIR/claude"
+    export KIRO_HOME="$SANDBOX_DIR/kiro"
+    export OMA_PROJECT_DIR="$PROJECT"
+    export NO_COLOR=1 OMA_QUIET=1
+}
+
+teardown() {
+    rm -rf "$SANDBOX_DIR"
+}
+
+# Helper: write a minimal profile.yaml with the requested aws.environment.
+write_profile() {
+    env="$1"
+    cat > "$PROJECT/.omao/profile.yaml" <<YAML
+version: 1
+created_at: "2026-05-09T00:00:00Z"
+harness: { primary: claude-code, secondary: null }
+aws:
+  account_id: "123456789012"
+  region: ap-northeast-2
+  profile_name: default
+  environment: $env
+aidlc: { entry_phase: inception, strict_gates: false }
+approval: { mode: interactive, blast_radius_ceiling: single-account }
+budgets: { default_monthly_usd: 200, warn_at_pct: 80, block_at_pct: 100 }
+observability: { mode: langfuse-managed, endpoint: null }
+YAML
+}
+
+# ---------------- Claude ----------------
+
+@test "claude.sh sandbox emits a non-empty permissions.deny" {
+    write_profile sandbox
+    run bash "$CLAUDE_INSTALL"
+    [ "$status" -eq 0 ]
+    settings="$CLAUDE_HOME/settings.json"
+    [ -f "$settings" ]
+    count=$(jq '.permissions.deny | length' "$settings")
+    [ "$count" -gt 0 ]
+}
+
+@test "claude.sh prod deny is strictly larger than sandbox deny" {
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    sandbox_count=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+
+    rm -rf "$CLAUDE_HOME"
+    write_profile prod
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    prod_count=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+
+    [ "$prod_count" -gt "$sandbox_count" ] || {
+        echo "expected prod ($prod_count) > sandbox ($sandbox_count)"
+        return 1
+    }
+}
+
+@test "claude.sh second run is idempotent (no duplicate deny entries)" {
+    write_profile prod
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    first=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    second=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+    [ "$first" -eq "$second" ]
+}
+
+@test "claude.sh preserves user-authored permissions.deny entries" {
+    write_profile sandbox
+    mkdir -p "$CLAUDE_HOME"
+    cat > "$CLAUDE_HOME/settings.json" <<'JSON'
+{
+  "permissions": {
+    "deny": ["Bash(rm -rf /)", "Edit(/Users/me/secret.txt)"]
+  }
+}
+JSON
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    # User's entries survive verbatim.
+    jq -e '.permissions.deny | index("Bash(rm -rf /)") != null' "$CLAUDE_HOME/settings.json"
+    jq -e '.permissions.deny | index("Edit(/Users/me/secret.txt)") != null' "$CLAUDE_HOME/settings.json"
+}
+
+@test "claude.sh --skip-permissions leaves permissions key absent" {
+    write_profile prod
+    run bash "$CLAUDE_INSTALL" --skip-permissions
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_HOME/settings.json" ]
+    # No permissions.deny added by us.
+    jq -e '.permissions == null or (.permissions.deny // [] | length == 0)' "$CLAUDE_HOME/settings.json"
+}
+
+@test "claude.sh OMA_PERMISSIONS_ENV overrides profile.yaml" {
+    write_profile sandbox
+    OMA_PERMISSIONS_ENV=prod bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    overridden=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+
+    rm -rf "$CLAUDE_HOME"
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    natural=$(jq '.permissions.deny | length' "$CLAUDE_HOME/settings.json")
+
+    [ "$overridden" -gt "$natural" ]
+}
+
+@test "claude.sh skips gracefully when profile.yaml is absent" {
+    rm -f "$PROJECT/.omao/profile.yaml"
+    run bash "$CLAUDE_INSTALL"
+    [ "$status" -eq 0 ]
+    # settings.json may exist (other steps run) but no permissions tree.
+    if [ -f "$CLAUDE_HOME/settings.json" ]; then
+        jq -e '.permissions == null or (.permissions.deny // [] | length == 0)' "$CLAUDE_HOME/settings.json"
+    fi
+}
+
+# ---------------- Kiro ----------------
+
+@test "kiro.sh prod tags agent.json with _meta.oma_permissions_env" {
+    write_profile prod
+    run bash "$KIRO_INSTALL"
+    [ "$status" -eq 0 ]
+    agent="$KIRO_HOME/agents/ai-infra.agent.json"
+    [ -f "$agent" ]
+    jq -e '._meta.oma_permissions_env == "prod"' "$agent"
+    jq -e '._meta.oma_permissions_deny.bash | length > 0' "$agent"
+}
+
+@test "kiro.sh sandbox keeps autoApprove.fileWrites=true" {
+    write_profile sandbox
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    jq -e '.autoApprove.fileWrites == true' "$KIRO_HOME/settings/cli.json"
+    jq -e '.autoApprove.fileWrites == true' "$KIRO_HOME/agents/ai-infra.agent.json"
+}
+
+@test "kiro.sh prod tightens autoApprove.bashCommands to false" {
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    jq -e '.autoApprove.bashCommands == false' "$KIRO_HOME/settings/cli.json"
+    jq -e '.autoApprove.bashCommands == false' "$KIRO_HOME/agents/ai-infra.agent.json"
+}
+
+@test "kiro.sh leaves source repo agent files unmodified" {
+    src="$REPO_ROOT/plugins/ai-infra/kiro-agents/ai-infra.agent.json"
+    before=$(shasum -a 256 "$src" | awk '{print $1}')
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    after=$(shasum -a 256 "$src" | awk '{print $1}')
+    [ "$before" = "$after" ]
+}
+
+@test "kiro.sh refuses to overwrite a hand-edited agent.json" {
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    agent="$KIRO_HOME/agents/ai-infra.agent.json"
+    # Strip OMA's audit tag — simulates a user who hand-edited the file.
+    tmp=$(mktemp)
+    jq 'del(._meta.oma_permissions_env)' "$agent" > "$tmp"
+    mv "$tmp" "$agent"
+    # Mark a sentinel field the install must not overwrite.
+    tmp=$(mktemp)
+    jq '.welcomeMessage = "USER_EDIT_SENTINEL"' "$agent" > "$tmp"
+    mv "$tmp" "$agent"
+
+    run bash "$KIRO_INSTALL"
+    [ "$status" -eq 0 ]
+    # Sentinel survives.
+    jq -e '.welcomeMessage == "USER_EDIT_SENTINEL"' "$agent"
+}
+
+@test "kiro.sh second run picks up upstream agent.json changes" {
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    agent="$KIRO_HOME/agents/ai-infra.agent.json"
+    src="$REPO_ROOT/plugins/ai-infra/kiro-agents/ai-infra.agent.json"
+    # Sanity — the OMA-tagged copy reflects the source description.
+    src_desc=$(jq -r '.description' "$src")
+    user_desc=$(jq -r '.description' "$agent")
+    [ "$src_desc" = "$user_desc" ]
+}
+
+@test "kiro.sh --skip-permissions does not write _meta.oma_permissions_env" {
+    write_profile prod
+    run bash "$KIRO_INSTALL" --skip-permissions
+    [ "$status" -eq 0 ]
+    agent="$KIRO_HOME/agents/ai-infra.agent.json"
+    # Either no agent yet or no _meta tag — both acceptable.
+    if [ -e "$agent" ]; then
+        # _meta may carry pre-existing keys (e.g. eks_mcp_flags). We only
+        # care that install_permissions did not stamp its env tag.
+        jq -e '._meta.oma_permissions_env == null' "$agent" || {
+            jq '._meta' "$agent"
+            return 1
+        }
+    fi
+}

--- a/tests/installer/test_install_permissions.bats
+++ b/tests/installer/test_install_permissions.bats
@@ -78,6 +78,21 @@ YAML
     [ "$first" -eq "$second" ]
 }
 
+@test "claude.sh stamps the OMA permissions sentinel after a successful install" {
+    write_profile sandbox
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    [ -f "$CLAUDE_HOME/.oma-permissions-applied-at" ]
+    # Sentinel mtime should not be older than the overlay file we'd compare it against.
+    sentinel_mtime=$(stat -f %m "$CLAUDE_HOME/.oma-permissions-applied-at" 2>/dev/null || stat -c %Y "$CLAUDE_HOME/.oma-permissions-applied-at")
+    [ "$sentinel_mtime" -gt 0 ]
+}
+
+@test "kiro.sh stamps the OMA permissions sentinel after a successful install" {
+    write_profile prod
+    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    [ -f "$KIRO_HOME/.oma-permissions-applied-at" ]
+}
+
 @test "claude.sh preserves user-authored permissions.deny entries" {
     write_profile sandbox
     mkdir -p "$CLAUDE_HOME"

--- a/tests/installer/test_install_permissions.bats
+++ b/tests/installer/test_install_permissions.bats
@@ -80,8 +80,21 @@ YAML
 
 @test "claude.sh stamps the OMA permissions sentinel after a successful install" {
     write_profile sandbox
-    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
-    [ -f "$CLAUDE_HOME/.oma-permissions-applied-at" ]
+    # Capture status + output so that a silent install_permissions early-return
+    # (e.g. PyYAML missing on the python3 the test inherits) surfaces here
+    # instead of bubbling up as a confusing `[ -f sentinel ]` failure two
+    # lines later.
+    run bash "$CLAUDE_INSTALL"
+    [ "$status" -eq 0 ] || {
+        echo "claude install exit=$status; output below:" >&2
+        echo "$output" >&2
+        return 1
+    }
+    [ -f "$CLAUDE_HOME/.oma-permissions-applied-at" ] || {
+        echo "sentinel missing — install output:" >&2
+        echo "$output" >&2
+        return 1
+    }
     # Sentinel mtime should not be older than the overlay file we'd compare it against.
     sentinel_mtime=$(stat -f %m "$CLAUDE_HOME/.oma-permissions-applied-at" 2>/dev/null || stat -c %Y "$CLAUDE_HOME/.oma-permissions-applied-at")
     [ "$sentinel_mtime" -gt 0 ]
@@ -89,7 +102,12 @@ YAML
 
 @test "kiro.sh stamps the OMA permissions sentinel after a successful install" {
     write_profile prod
-    bash "$KIRO_INSTALL" >/dev/null 2>&1
+    run bash "$KIRO_INSTALL"
+    [ "$status" -eq 0 ] || {
+        echo "kiro install exit=$status; output below:" >&2
+        echo "$output" >&2
+        return 1
+    }
     [ -f "$KIRO_HOME/.oma-permissions-applied-at" ]
 }
 

--- a/tests/installer/test_permissions_lib.bats
+++ b/tests/installer/test_permissions_lib.bats
@@ -149,6 +149,84 @@ EOF
     done <<< "$out"
 }
 
+@test "overlay deny.add appends to the resolved set" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    cat > "$proj/.omao/permissions.yaml" <<'EOF'
+version: 1
+deny:
+  add:
+    edit: ["infra/secrets/**"]
+EOF
+    has=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq '.deny.edit | any(test(\"infra/secrets\"))'")
+    rm -rf "$proj"
+    [ "$has" = "true" ]
+}
+
+@test "overlay deny.remove subtracts from the resolved set" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    # Pick an entry that's actually in prod.
+    target="kubectl delete ns*"
+    cat > "$proj/.omao/permissions.yaml" <<EOF
+version: 1
+deny:
+  remove:
+    bash: ["$target"]
+EOF
+    base_count=$(bash -c ". '$LIB' && perms_resolve prod | jq '.deny.bash | length'")
+    overlay_count=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq '.deny.bash | length'")
+    rm -rf "$proj"
+    [ "$overlay_count" -eq $((base_count - 1)) ]
+}
+
+@test "overlay auto_approve.bash_commands=true overrides prod default false" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    cat > "$proj/.omao/permissions.yaml" <<'EOF'
+version: 1
+auto_approve:
+  bash_commands: true
+EOF
+    out=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq -r '.auto_approve.bash_commands'")
+    rm -rf "$proj"
+    [ "$out" = "true" ]
+}
+
+@test "absent overlay leaves base resolution unchanged" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    base=$(bash -c ". '$LIB' && perms_resolve prod | jq -c .")
+    overlay=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq -c 'del(._meta.overlay_path, ._meta.overlay_applied)'")
+    rm -rf "$proj"
+    [ "$base" = "$overlay" ]
+}
+
+@test "overlay marks _meta.overlay_applied true when any rule fires" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    cat > "$proj/.omao/permissions.yaml" <<'EOF'
+version: 1
+deny:
+  add:
+    bash: ["echo overlay-only"]
+EOF
+    flag=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq -r '._meta.overlay_applied'")
+    rm -rf "$proj"
+    [ "$flag" = "true" ]
+}
+
+@test "overlay with empty schema does not set overlay_applied" {
+    proj=$(mktemp -d)
+    mkdir -p "$proj/.omao"
+    cat > "$proj/.omao/permissions.yaml" <<'EOF'
+version: 1
+EOF
+    flag=$(bash -c ". '$LIB' && perms_resolve_with_overlays prod '$proj' | jq -r '._meta.overlay_applied'")
+    rm -rf "$proj"
+    [ "$flag" = "false" ]
+}
+
 @test "perms_resolve_for_profile reads aws.environment from a profile file" {
     tmp_profile="$(mktemp)"
     cat > "$tmp_profile" <<'YAML'

--- a/tests/installer/test_permissions_lib.bats
+++ b/tests/installer/test_permissions_lib.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# tests/installer/test_permissions_lib.bats
+# Unit tests for scripts/lib/permissions.sh — the shared resolver that turns
+# templates/permissions/<env>.yaml into the JSON document both install
+# scripts ingest. Verifies extends-merge semantics (arrays union+uniq+sort,
+# scalars child-wins), env validation, and the Claude / Kiro emitters.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIB="$REPO_ROOT/scripts/lib/permissions.sh"
+    export NO_COLOR=1 OMA_QUIET=1
+}
+
+# Source the lib in a subshell and run a small jq pipeline on the resolved
+# document. Keeps each @test case to one assertion.
+resolve_jq() {
+    env="$1"; expr="$2"
+    bash -c ". '$LIB' && perms_resolve '$env'" | jq -r "$expr"
+}
+
+@test "perms_resolve sandbox emits the documented schema shape" {
+    json=$(bash -c ". '$LIB' && perms_resolve sandbox")
+    echo "$json" | jq -e '
+        has("auto_approve") and has("deny") and has("_meta")
+        and (.auto_approve | type) == "object"
+        and (.deny.bash  | type) == "array"
+        and (.deny.edit  | type) == "array"
+        and (.deny.write | type) == "array"
+        and (.deny.mcp   | type) == "array"
+    '
+}
+
+@test "perms_resolve rejects unknown env with non-zero status" {
+    run bash -c ". '$LIB' && perms_resolve nope"
+    [ "$status" -ne 0 ]
+}
+
+@test "perms_resolve <env> includes common.yaml in the templates chain" {
+    run resolve_jq sandbox '._meta.templates | join(",")'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "common.yaml,sandbox.yaml" ]]
+}
+
+@test "common audit-ledger guard is inherited by every env" {
+    for env in sandbox staging prod; do
+        run resolve_jq "$env" '.deny.bash | map(select(test("audit"))) | length > 0'
+        [ "$status" -eq 0 ]
+        [ "$output" = "true" ] || {
+            echo "$env did not inherit the audit ledger guard"
+            return 1
+        }
+    done
+}
+
+@test "deny arrays are unique and sorted" {
+    json=$(bash -c ". '$LIB' && perms_resolve prod")
+    echo "$json" | jq -e '
+        (.deny.bash  == (.deny.bash  | unique | sort))
+        and (.deny.edit  == (.deny.edit  | unique | sort))
+        and (.deny.write == (.deny.write | unique | sort))
+        and (.deny.mcp   == (.deny.mcp   | unique | sort))
+    '
+}
+
+@test "sandbox auto-approves bash but prod does not" {
+    run resolve_jq sandbox '.auto_approve.bash_commands'
+    [ "$status" -eq 0 ]; [ "$output" = "true" ]
+    run resolve_jq prod '.auto_approve.bash_commands'
+    [ "$status" -eq 0 ]; [ "$output" = "false" ]
+}
+
+@test "auto_approve.read_only stays true across all envs" {
+    for env in sandbox staging prod; do
+        run resolve_jq "$env" '.auto_approve.read_only'
+        [ "$status" -eq 0 ]
+        [ "$output" = "true" ]
+    done
+}
+
+@test "prod deny set is a strict superset of staging" {
+    staging=$(bash -c ". '$LIB' && perms_resolve staging | jq -r '.deny.bash[]'")
+    prod=$(bash    -c ". '$LIB' && perms_resolve prod    | jq -r '.deny.bash[]'")
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        echo "$prod" | grep -Fxq "$line" || {
+            echo "staging deny entry missing from prod: $line"
+            return 1
+        }
+    done <<< "$staging"
+}
+
+@test "perms_to_claude_deny wraps bash/edit/write and leaves mcp bare" {
+    out=$(bash -c ". '$LIB' && perms_resolve prod | perms_to_claude_deny")
+    # Bash entries
+    echo "$out" | jq -e 'map(select(startswith("Bash("))) | length > 0'
+    # Edit entries
+    echo "$out" | jq -e 'map(select(startswith("Edit("))) | length > 0'
+    # Write entries
+    echo "$out" | jq -e 'map(select(startswith("Write("))) | length > 0'
+    # MCP entries left bare (no wrapping prefix)
+    echo "$out" | jq -e 'map(select(startswith("mcp__"))) | length > 0'
+}
+
+@test "perms_to_kiro_autoapprove emits Kiro key casing" {
+    out=$(bash -c ". '$LIB' && perms_resolve sandbox | perms_to_kiro_autoapprove")
+    echo "$out" | jq -e 'has("readOnly") and has("fileWrites") and has("bashCommands")'
+}
+
+@test "perms_print_summary lines stay under 100 chars" {
+    out=$(bash -c ". '$LIB' && resolved=\$(perms_resolve prod); perms_print_summary \"\$resolved\"" 2>&1)
+    while IFS= read -r line; do
+        len=${#line}
+        [ "$len" -lt 100 ] || {
+            echo "summary line too long ($len chars): $line"
+            return 1
+        }
+    done <<< "$out"
+}
+
+@test "perms_resolve_for_profile reads aws.environment from a profile file" {
+    tmp_profile="$(mktemp)"
+    cat > "$tmp_profile" <<'YAML'
+version: 1
+created_at: "2026-05-09T00:00:00Z"
+harness: { primary: claude-code, secondary: null }
+aws:
+  account_id: "123456789012"
+  region: ap-northeast-2
+  environment: staging
+aidlc: { entry_phase: inception }
+approval: { mode: interactive }
+budgets: { default_monthly_usd: 100, warn_at_pct: 80, block_at_pct: 100 }
+observability: { mode: none }
+YAML
+    out=$(bash -c ". '$LIB' && perms_resolve_for_profile '$tmp_profile' | jq -r '._meta.env'")
+    rm -f "$tmp_profile"
+    [ "$out" = "staging" ]
+}

--- a/tests/installer/test_permissions_lib.bats
+++ b/tests/installer/test_permissions_lib.bats
@@ -77,6 +77,38 @@ resolve_jq() {
     done
 }
 
+@test "child template can override parent auto_approve true to false" {
+    # Regression for the jq `//` falsy collapse: if the merge uses
+    # `(child.k // parent.k)`, a child setting `false` against a parent set
+    # to `true` produces `true` (jq treats `false` as a null alternative).
+    # The fix uses explicit `has(k)` so the child's literal `false` is
+    # honored.
+    tmpl_dir="$(mktemp -d)"
+    cat > "$tmpl_dir/common.yaml" <<'EOF'
+version: 1
+deny: { bash: [], edit: [], write: [], mcp: [] }
+auto_approve: { read_only: true, file_writes: true, bash_commands: true }
+EOF
+    cat > "$tmpl_dir/sandbox.yaml" <<'EOF'
+version: 1
+extends: ["common.yaml"]
+deny: { bash: [], edit: [], write: [], mcp: [] }
+auto_approve: { read_only: true, file_writes: false, bash_commands: false }
+EOF
+
+    out=$(bash -c "
+        . '$LIB'
+        perms_template_dir() { printf '%s' '$tmpl_dir'; }
+        perms_resolve sandbox | jq -c '.auto_approve'
+    ")
+    rm -rf "$tmpl_dir"
+
+    [ "$out" = '{"read_only":true,"file_writes":false,"bash_commands":false}' ] || {
+        echo "got: $out"
+        return 1
+    }
+}
+
 @test "prod deny set is a strict superset of staging" {
     staging=$(bash -c ". '$LIB' && perms_resolve staging | jq -r '.deny.bash[]'")
     prod=$(bash    -c ". '$LIB' && perms_resolve prod    | jq -r '.deny.bash[]'")

--- a/tests/installer/test_permissions_overlay.bats
+++ b/tests/installer/test_permissions_overlay.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/installer/test_permissions_overlay.bats
+# Coverage for the project-level overlay (.omao/permissions.yaml) end-to-end:
+#   - `oma permissions show` / `path` subcommand
+#   - install_permissions reflects the overlay
+#   - doctor probe expects the overlay-resolved deny set
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    OMA_BIN="$REPO_ROOT/bin/oma"
+    CLAUDE_INSTALL="$REPO_ROOT/scripts/install/claude.sh"
+    SANDBOX_DIR="$(mktemp -d)"
+    PROJECT="$SANDBOX_DIR/proj"
+    mkdir -p "$PROJECT/.omao"
+    export HOME="$SANDBOX_DIR/home"
+    export CLAUDE_HOME="$HOME/.claude"
+    export OMA_PROJECT_DIR="$PROJECT"
+    mkdir -p "$HOME"
+    export NO_COLOR=1 OMA_QUIET=1
+}
+
+teardown() {
+    rm -rf "$SANDBOX_DIR"
+}
+
+write_profile() {
+    env="$1"
+    cat > "$PROJECT/.omao/profile.yaml" <<YAML
+version: 1
+created_at: "2026-05-09T00:00:00Z"
+harness: { primary: claude-code, secondary: null }
+aws:
+  account_id: "123456789012"
+  region: ap-northeast-2
+  environment: $env
+aidlc: { entry_phase: inception }
+approval: { mode: interactive }
+budgets: { default_monthly_usd: 200, warn_at_pct: 80, block_at_pct: 100 }
+observability: { mode: langfuse-managed, endpoint: null }
+YAML
+}
+
+write_overlay() {
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+deny:
+  remove:
+    bash: ["kubectl delete ns*"]
+  add:
+    edit: ["infra/secrets/**"]
+auto_approve:
+  bash_commands: true
+YAML
+}
+
+# ---------------- oma permissions ----------------
+
+@test "oma permissions path creates .omao/ and prints absolute path" {
+    write_profile prod
+    run "$OMA_BIN" permissions path --project "$PROJECT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "$PROJECT/.omao/permissions.yaml" ]]
+    [ -d "$PROJECT/.omao" ]
+}
+
+@test "oma permissions show with no overlay reports (none)" {
+    write_profile prod
+    run "$OMA_BIN" permissions show --project "$PROJECT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"overlay : (none"* ]]
+    [[ "$output" == *"templates : common.yaml + prod.yaml"* ]]
+}
+
+@test "oma permissions show with overlay tags entries by source" {
+    write_profile prod
+    write_overlay
+    run "$OMA_BIN" permissions show --project "$PROJECT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"applied"* ]]
+    [[ "$output" == *"[overlay"*"infra/secrets/**"* ]]
+    [[ "$output" == *"overlay removals"* ]]
+    [[ "$output" == *"kubectl delete ns*"* ]]
+}
+
+@test "oma permissions show --json carries overlay_applied flag" {
+    write_profile prod
+    write_overlay
+    run "$OMA_BIN" permissions show --project "$PROJECT" --json
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.overlay_applied == true'
+    echo "$output" | jq -e '.removed.bash | length == 1'
+}
+
+@test "oma permissions show fails on unknown env" {
+    write_profile prod
+    sed -i.bak 's/environment: prod/environment: nope/' "$PROJECT/.omao/profile.yaml"
+    rm -f "$PROJECT/.omao/profile.yaml.bak"
+    run "$OMA_BIN" permissions show --project "$PROJECT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported aws.environment"* ]]
+}
+
+# ---------------- install reflects overlay ----------------
+
+@test "claude.sh install_permissions honors overlay deny.remove" {
+    write_profile prod
+    write_overlay
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    # Removed entry must NOT be in the live deny set.
+    jq -e '.permissions.deny | any(. == "Bash(kubectl delete ns*)") | not' \
+        "$CLAUDE_HOME/settings.json"
+}
+
+@test "claude.sh install_permissions honors overlay deny.add" {
+    write_profile prod
+    write_overlay
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+    jq -e '.permissions.deny | any(. == "Edit(infra/secrets/**)")' \
+        "$CLAUDE_HOME/settings.json"
+}
+
+# ---------------- doctor reflects overlay ----------------
+
+@test "doctor probe passes when overlay is applied to the install" {
+    write_profile prod
+    write_overlay
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1
+
+    # Source probe in isolation (skips unrelated baseline failures).
+    out=$(bash -c '
+        set +e
+        REPO_ROOT="'"$REPO_ROOT"'"
+        PROJECT_DIR="'"$PROJECT"'"
+        . "$REPO_ROOT/scripts/lib/log.sh"
+        PROBE_IDS=(); PROBE_LABELS=(); PROBE_STATUSES=(); PROBE_MESSAGES=(); PROBE_REMEDIATIONS=()
+        record() {
+            PROBE_IDS+=("$1"); PROBE_LABELS+=("$2"); PROBE_STATUSES+=("$3")
+            PROBE_MESSAGES+=("$4"); PROBE_REMEDIATIONS+=("${5:-}")
+        }
+        eval "$(awk "/^probe_permissions_applied\\(\\)/,/^}$/" "$REPO_ROOT/scripts/oma/doctor.sh")"
+        probe_permissions_applied
+        printf "STATUS=%s\nMESSAGE=%s\n" "${PROBE_STATUSES[-1]}" "${PROBE_MESSAGES[-1]}"
+    ')
+    echo "$out" | grep -q '^STATUS=pass$'
+}
+
+@test "doctor probe warns when overlay edited but install not re-run" {
+    write_profile prod
+    bash "$CLAUDE_INSTALL" >/dev/null 2>&1   # no overlay yet -> baseline applied
+    write_overlay                            # add overlay AFTER install
+    out=$(bash -c '
+        set +e
+        REPO_ROOT="'"$REPO_ROOT"'"
+        PROJECT_DIR="'"$PROJECT"'"
+        . "$REPO_ROOT/scripts/lib/log.sh"
+        PROBE_IDS=(); PROBE_LABELS=(); PROBE_STATUSES=(); PROBE_MESSAGES=(); PROBE_REMEDIATIONS=()
+        record() {
+            PROBE_IDS+=("$1"); PROBE_LABELS+=("$2"); PROBE_STATUSES+=("$3")
+            PROBE_MESSAGES+=("$4"); PROBE_REMEDIATIONS+=("${5:-}")
+        }
+        eval "$(awk "/^probe_permissions_applied\\(\\)/,/^}$/" "$REPO_ROOT/scripts/oma/doctor.sh")"
+        probe_permissions_applied
+        printf "STATUS=%s\nMESSAGE=%s\n" "${PROBE_STATUSES[-1]}" "${PROBE_MESSAGES[-1]}"
+    ')
+    echo "$out" | grep -q '^STATUS=warn$'
+    # The overlay added Edit(infra/secrets/**); probe should report it missing.
+    echo "$out" | grep -q 'missing deny entries'
+}

--- a/tests/profile/test_setup_non_interactive.bats
+++ b/tests/profile/test_setup_non_interactive.bats
@@ -35,6 +35,55 @@ teardown() {
     [ -f "$PROJECT/.omao/ontology/budgets/default.json" ]
     [ -f "$PROJECT/.omao/ontology/deployments/example.json" ]
     [ -f "$PROJECT/.omao/ontology/risks/bootstrap.json" ]
+    [ -f "$PROJECT/.omao/permissions.yaml" ]
+}
+
+@test "setup seeds permissions.yaml as a no-op overlay (all commented)" {
+    run env -i PATH="$PATH" HOME="$HOME" \
+        OMA_NON_INTERACTIVE=1 OMA_HARNESS=claude-code \
+        OMA_AWS_ACCOUNT=123456789012 OMA_AWS_REGION=ap-northeast-2 \
+        OMA_AWS_ENV=prod OMA_AIDLC_PHASE=inception \
+        OMA_APPROVAL_MODE=interactive OMA_BUDGET_USD=200 \
+        OMA_OBSERVABILITY=langfuse-managed \
+        bash -c "cd '$PROJECT' && '$OMA_BIN' setup --non-interactive --skip-install --skip-doctor"
+    [ "$status" -eq 0 ]
+    [ -f "$PROJECT/.omao/permissions.yaml" ]
+    # Resolved chain with the seeded overlay must equal the base resolution.
+    base=$(bash -c ". '$REPO_ROOT/scripts/lib/permissions.sh' && perms_resolve prod | jq -c '.deny'")
+    overlay=$(bash -c ". '$REPO_ROOT/scripts/lib/permissions.sh' && perms_resolve_with_overlays prod '$PROJECT' | jq -c '.deny'")
+    [ "$base" = "$overlay" ] || {
+        echo "base=$base"; echo "overlay=$overlay"; return 1
+    }
+    # _meta.overlay_applied stays false because no rule actually fires.
+    flag=$(bash -c ". '$REPO_ROOT/scripts/lib/permissions.sh' && perms_resolve_with_overlays prod '$PROJECT' | jq -r '._meta.overlay_applied'")
+    [ "$flag" = "false" ]
+}
+
+@test "setup re-run preserves a hand-edited permissions.yaml" {
+    env -i PATH="$PATH" HOME="$HOME" \
+        OMA_NON_INTERACTIVE=1 OMA_HARNESS=claude-code \
+        OMA_AWS_ACCOUNT=123456789012 OMA_AWS_REGION=ap-northeast-2 \
+        OMA_AWS_ENV=sandbox OMA_AIDLC_PHASE=inception \
+        OMA_APPROVAL_MODE=interactive OMA_BUDGET_USD=200 \
+        OMA_OBSERVABILITY=langfuse-managed \
+        bash -c "cd '$PROJECT' && '$OMA_BIN' setup --non-interactive --skip-install --skip-doctor" >/dev/null 2>&1
+    # User customizes the overlay
+    cat > "$PROJECT/.omao/permissions.yaml" <<'YAML'
+version: 1
+deny:
+  add:
+    bash: ["my-team-only-pattern"]
+YAML
+    # Re-run setup
+    run env -i PATH="$PATH" HOME="$HOME" \
+        OMA_NON_INTERACTIVE=1 OMA_HARNESS=claude-code \
+        OMA_AWS_ACCOUNT=123456789012 OMA_AWS_REGION=ap-northeast-2 \
+        OMA_AWS_ENV=sandbox OMA_AIDLC_PHASE=inception \
+        OMA_APPROVAL_MODE=interactive OMA_BUDGET_USD=200 \
+        OMA_OBSERVABILITY=langfuse-managed \
+        bash -c "cd '$PROJECT' && '$OMA_BIN' setup --non-interactive --skip-install --skip-doctor"
+    [ "$status" -eq 0 ]
+    grep -q 'my-team-only-pattern' "$PROJECT/.omao/permissions.yaml"
 }
 
 @test "setup --dry-run does not create files" {


### PR DESCRIPTION
  Issue #, if available:
  
  (none)

  Description of changes:

  Adds a permission policy layer that constrains the tools and resource paths OMA agents can call on each host harness. The policy is environment-scoped (profile.yaml aws.environment),
   customizable per project, and surfaces drift back to the user automatically.

  What's new:
  - templates/permissions/{common,sandbox,staging,prod}.yaml — abstract deny templates emitted into both Claude (permissions.deny[]) and Kiro (autoApprove + agents/*.agent.json).
  - <project>/.omao/permissions.yaml — user-owned overlay with deny.add / deny.remove / auto_approve overrides. Seeded as a no-op (commented) on first oma setup.
  - scripts/lib/permissions.sh — shared resolver (perms_resolve_with_overlays, perms_to_claude_deny, perms_to_kiro_autoapprove) consumed by both install scripts.
  - install_permissions() in scripts/install/{claude,kiro}.sh — non-destructive append-uniq merge that preserves user-authored entries; rewrites OMA-owned Kiro agent copies from source
   on every run; refuses to overwrite hand-edited copies.
  - oma permissions [show|path] — inspect resolved chain with per-entry provenance (common/env/overlay) and overlay add/remove counts.
  - permissions-applied doctor probe — verifies the live deny set is a superset of the resolved template; warns on drift.
  - Drift hook — hooks/{session-start,user-prompt-submit}.sh emit OMA_PERMISSIONS_DRIFT when the overlay is newer than an OMA-owned sentinel
  (<harness_home>/.oma-permissions-applied-at). Sentinel-based comparison avoids false negatives caused by Claude/Kiro touching their own settings for unrelated reasons (telemetry,
  model cache).
  
  Bundled fixes (regressions caught while wiring this up):
  - merge_one in the resolver: child template's explicit auto_approve.*: false now overrides a parent's true (jq's // collapsed false into the parent value).
  - detect_claude_version in scripts/install/claude.sh: trailing || true keeps the silent-fallback intent under set -euo pipefail when wrapper claude binaries (toolbox / asdf) exit
  non-zero.
  
  Defaults are floor-only. The shipped templates only block operations whose accidental execution is hard to reverse (sandbox=5, staging=11, prod=28 deny entries). Routine paths
  (kubectl apply/patch, helm upgrade, aws iam create/attach, manifest edits) remain available. The user can always remove an entry from ~/.claude/settings.json or via deny.remove in
  the overlay.

  Backwards compatibility:
  - oma setup / installers seed and merge non-destructively. Existing user-authored permissions.deny[] entries preserved verbatim.
  - --skip-permissions / OMA_SKIP_PERMISSIONS=1 opt-out flag and OMA_PERMISSIONS_ENV override for CI.
  - No source-repo file is mutated by Kiro install (verified: git status clean across the install round-trip).

  Verification:
  - 95 PASS / 2 pre-existing FAIL (enterprise-smoke baseline) across tests/installer, tests/hooks, tests/profile. 51 new bats cases.
  - shellcheck clean on all touched scripts.
  - End-to-end manual verification on Claude Code 2.1.136: edit .omao/permissions.yaml mid-session → next prompt surfaces the drift reminder; re-run install → reminder clears.
  
  Note on stacking: depends on fix/hook-context-delivery for the drift hook to actually surface in Claude Code 2.x. Recommend merging that fix branch first; this branch will rebase
  cleanly afterward.

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.