### PR TITLE
fix(landing): correct hero badge version and drop inaccurate "API" wording

### DIFF
--- a/docs/src/components/HomeLanding/index.tsx
+++ b/docs/src/components/HomeLanding/index.tsx
@@ -325,7 +325,7 @@ export default function HomeLanding(): React.ReactElement {
             <div className={styles.previewBadge} role="note">
               <span className={styles.previewBadgeLabel}>Tech Preview</span>
               <span className={styles.previewBadgeText}>
-                v0.3.0-preview.1 — API may change before GA. See the{' '}
+                v0.4.0-preview.1 — schemas &amp; DSL may change before GA. See the{' '}
                 <Link to={useBaseUrl('/docs/support-policy')}>support policy</Link>.
               </span>
             </div>


### PR DESCRIPTION
## Summary

The homepage hero Tech Preview badge read **"v0.3.0-preview.1 — API may change before GA."** Two issues:

1. **Stale version** — current release is `v0.4.0-preview.1`.
2. **"API" is inaccurate** — OMA ships plugins, pinned MCP servers, and the ontology / harness DSL. There is no public API surface. Reworded to **"schemas & DSL may change before GA"**, matching what the support policy actually governs.

## Scope
- `docs/src/components/HomeLanding/index.tsx` — one badge string.
- The `API` reference in `releases.tsx` is intentionally left as-is (it refers to the GitHub Releases API).

## Verification
- `npm run build` passes (0 link warnings, TSX compiles).