### PR TITLE
fix(deps): close webpack-dev-server & ws Dependabot alerts (docs)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19140,9 +19140,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
@@ -19224,27 +19224,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-merge": {
@@ -19491,16 +19470,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,9 +29,10 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "webpack-dev-server": "5.2.3",
+    "webpack-dev-server": "5.2.4",
     "webpack": "5.105.1",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",


### PR DESCRIPTION
## Summary

Closes the two open Dependabot alerts on the docs site (both **medium**, both dev/build-time deps of the Docusaurus site — not shipped to users):

| Alert | Package | Advisory | Fix |
|---|---|---|---|
| #9 | webpack-dev-server <= 5.2.3 | GHSA-79cf-xcqc-c78w (cross-origin source exposure on non-HTTPS) | bump override 5.2.3 → **5.2.4** |
| #11 | ws >= 8.0.0, < 8.20.1 | GHSA-58qx-3vcg-4xpx (uninitialized memory disclosure) | add **ws >= 8.20.1** override |

## Why the override change

`webpack-dev-server` was **pinned at 5.2.3 in the `overrides` block**, which blocked Dependabot's own fix. Bumping it to 5.2.4 pulls `ws@^8.18.0`; an explicit `ws >= 8.20.1` override ensures every transitive path (incl. webpack-bundle-analyzer) resolves to a patched `ws`. The tree now resolves **ws@8.21.0** everywhere.

## Verification
- `npm audit`: **0 vulnerabilities**
- `npm ls ws`: all 8.21.0; `webpack-dev-server`: 5.2.4
- Docusaurus production build passes (0 link warnings, 0 broken links)
- lockfile regenerated with npm 11