### PR TITLE
fix(docs): localize the landing page so it renders Korean under defaultLocale ko (#29)

### DIFF
--- a/docs/i18n/ko/code.json
+++ b/docs/i18n/ko/code.json
@@ -1,0 +1,861 @@
+{
+  "page.home.title": {
+    "message": "AIDLC × AgenticOps 마켓플레이스",
+    "description": "Home page title"
+  },
+  "page.home.description": {
+    "message": "Claude Code와 Kiro를 AgenticOps 플러그인과 스킬로 확장하여 AWS AI 주도 개발 수명주기(Inception, Construction, Operations)를 자동화합니다.",
+    "description": "Home page description"
+  },
+  "landing.plugin.ai_infra.tagline": {
+    "message": "런타임을 구축합니다.",
+    "description": "Tagline for ai-infra plugin"
+  },
+  "landing.plugin.ai_infra.scope": {
+    "message": "AWS 위 AI 런타임 인프라. EKS + vLLM + Inference Gateway + Langfuse + GPU + guardrails를 제공하며, Bedrock / SageMaker 런타임 스킬은 계획 중입니다. MCP 서버는 정확한 PyPI 버전으로 pin — @latest 사용 안 함.",
+    "description": "Description of ai-infra plugin scope"
+  },
+  "landing.plugin.aidlc.tagline": {
+    "message": "스펙을 기반으로 설계하고 구축합니다.",
+    "description": "Tagline for aidlc plugin"
+  },
+  "landing.plugin.aidlc.scope": {
+    "message": "awslabs/aidlc-workflows를 위한 AIDLC Phase 1 (Inception) + Phase 2 (Construction) opt-in 확장. Inception은 워크스페이스, 요구사항, 스토리, 워크플로우 계획을 포착합니다. Construction은 그 계획을 컴포넌트, 코드, 테스트, 리스크가 발견된 품질 게이트로 전환합니다.",
+    "description": "Description of aidlc plugin scope"
+  },
+  "landing.plugin.agenticops.tagline": {
+    "message": "에이전트로 운영합니다.",
+    "description": "Tagline for agenticops plugin"
+  },
+  "landing.plugin.agenticops.scope": {
+    "message": "프로덕션 에이전틱 워크로드를 위한 자율 운영. 인시던트 대응, 자가 개선 피드백 루프, SLO 서킷 브레이커가 있는 점진적 롤아웃, simpleeval 샌드박스 기반 비용 거버넌스, 그리고 verbatim 감사 추적.",
+    "description": "Description of agenticops plugin scope"
+  },
+  "landing.plugin.modernization.tagline": {
+    "message": "레거시를 AWS로 이전합니다.",
+    "description": "Tagline for modernization plugin"
+  },
+  "landing.plugin.modernization.scope": {
+    "message": "AWS 6R 전략을 사용한 브라운필드 레거시 워크로드 모더나이제이션. Five Lenses를 통한 워크로드 평가, 6R 의사결정 매트릭스, to-be 아키텍처, 컨테이너화 강화, 롤백 트리거가 있는 프로덕션 cutover 계획.",
+    "description": "Description of modernization plugin scope"
+  },
+  "landing.workflow.autopilot.scope": {
+    "message": "전체 AIDLC 루프 (Inception → Construction → Operations).",
+    "description": "Description of autopilot workflow"
+  },
+  "landing.workflow.aidlc_loop.scope": {
+    "message": "단일 기능 Inception → Construction 1회전.",
+    "description": "Description of aidlc-loop workflow"
+  },
+  "landing.workflow.inception.scope": {
+    "message": "AIDLC Phase 1 단독 — 스펙, 스토리, 워크플로우 계획.",
+    "description": "Description of inception workflow"
+  },
+  "landing.workflow.construction.scope": {
+    "message": "AIDLC Phase 2 단독 — 설계, 코드 생성, 에이전틱 TDD.",
+    "description": "Description of construction workflow"
+  },
+  "landing.workflow.agenticops.scope": {
+    "message": "운영 모드: continuous-eval + incident-response + cost-governance.",
+    "description": "Description of agenticops workflow"
+  },
+  "landing.workflow.self_improving.scope": {
+    "message": "Langfuse 트레이스 (구성된 trace MCP 사용) → 프롬프트 / 스킬 개선 PR.",
+    "description": "Description of self-improving workflow"
+  },
+  "landing.workflow.platform_bootstrap.scope": {
+    "message": "EKS 위 5-체크포인트 Agentic AI Platform 부트스트랩.",
+    "description": "Description of platform-bootstrap workflow"
+  },
+  "landing.workflow.modernize.scope": {
+    "message": "6단계 브라운필드 모더나이제이션 (평가 → cutover).",
+    "description": "Description of modernize workflow"
+  },
+  "landing.workflow.cancel.scope": {
+    "message": "활성 Tier-0 모드 종료.",
+    "description": "Description of cancel workflow"
+  },
+  "landing.superpower.1.title": {
+    "message": "한 커맨드, 전체 라이프사이클.",
+    "description": "Title for superpower 1"
+  },
+  "landing.superpower.1.body": {
+    "message": "스펙 → 설계 → 코드 → 카나리 배포 → 자가 치유 → 비용 귀속. /oma:autopilot이 전체 루프를 주도하며 명시적 승인 체크포인트에서만 멈춥니다.",
+    "description": "Body text for superpower 1"
+  },
+  "landing.superpower.2.title": {
+    "message": "프로덕션 트레이스에서 자가 개선.",
+    "description": "Title for superpower 2"
+  },
+  "landing.superpower.2.body": {
+    "message": "자체 Langfuse + trace 읽기 MCP를 구성하면 (프로파일 observability.trace_mcp를 통해), 트레이스가 /oma:self-improving에 공급됩니다. 실패 패턴은 이를 생성한 스킬과 프롬프트에 대한 초안 PR이 되며 — 회귀 테스트는 PR이 열리기 전에 실행됩니다.",
+    "description": "Body text for superpower 2"
+  },
+  "landing.superpower.3.title": {
+    "message": "사람은 승인하고, 에이전트가 실행합니다.",
+    "description": "Title for superpower 3"
+  },
+  "landing.superpower.3.body": {
+    "message": "모든 Tier-0 워크플로우는 에이전트 기반 진단, 제안, 실행을 명시적 인간 게이트 사이에 배치합니다. 에이전트는 절대 조용히 프로덕션을 변경하지 않습니다.",
+    "description": "Body text for superpower 3"
+  },
+  "landing.capability.autopilot.title": {
+    "message": "Autopilot 배포",
+    "description": "Title for autopilot deploys capability"
+  },
+  "landing.capability.autopilot.body": {
+    "message": "autopilot-deploy는 SLO 게이트 서킷 브레이커와 함께 카나리 1% → 10% → 50% → 100%를 실행합니다. 각 단계는 승격 전에 continuous-eval을 대기하며, 회귀가 발생하면 자동 롤백됩니다.",
+    "description": "Body text for autopilot deploys capability"
+  },
+  "landing.capability.autopilot.bullet1": {
+    "message": "Argo Rollouts / Flagger",
+    "description": "First bullet for autopilot deploys"
+  },
+  "landing.capability.autopilot.bullet2": {
+    "message": "Prometheus SLO 게이트",
+    "description": "Second bullet for autopilot deploys"
+  },
+  "landing.capability.autopilot.bullet3": {
+    "message": "100%에서 인간 승인",
+    "description": "Third bullet for autopilot deploys"
+  },
+  "landing.capability.self_healing.title": {
+    "message": "자가 치유",
+    "description": "Title for self-healing capability"
+  },
+  "landing.capability.self_healing.body": {
+    "message": "incident-response는 SEV1–4를 분류하고, 매칭되는 runbook을 가져와, 진단 MCP 쿼리를 발행하며, 승인을 위한 복구 스크립트를 작성합니다. SEV1은 on-call을 호출하며, 절대 자동 실행하지 않습니다.",
+    "description": "Body text for self-healing capability"
+  },
+  "landing.capability.cost_governance.title": {
+    "message": "비용 거버넌스",
+    "description": "Title for cost governance capability"
+  },
+  "landing.capability.cost_governance.body": {
+    "message": "cost-governance는 에이전트별로 지출을 귀속시키고, 월간 한도를 위반할 배포를 거부하며, Opus → Sonnet → Haiku 다운그레이드 PR을 작성합니다. budget.yaml은 simpleeval 샌드박스에서 실행 — Python eval 없음, RCE 벡터 없음.",
+    "description": "Body text for cost governance capability"
+  },
+  "landing.capability.cli_first.title": {
+    "message": "CLI 우선. 항상.",
+    "description": "Title for CLI first capability"
+  },
+  "landing.capability.cli_first.body": {
+    "message": "모든 스킬은 Claude Code에서 슬래시 커맨드로, Kiro에서 직접 스킬 호출로 접근 가능합니다. 전체 상태는 .omao/ 아래에 있으며 하네스 간 이식 가능합니다.",
+    "description": "Body text for CLI first capability"
+  },
+  "landing.integration.claude_code.title": {
+    "message": "Claude Code 플러그인",
+    "description": "Title for Claude Code integration"
+  },
+  "landing.integration.claude_code.body": {
+    "message": "네이티브 Claude Code 마켓플레이스 항목으로 제공됩니다. 슬래시 커맨드, 키워드 트리거, AWS hosted MCP 레이어가 즉시 작동합니다.",
+    "description": "Body text for Claude Code integration"
+  },
+  "landing.integration.kiro.title": {
+    "message": "Kiro 스킬",
+    "description": "Title for Kiro integration"
+  },
+  "landing.integration.kiro.body": {
+    "message": "install/kiro.sh가 모든 스킬을 ~/.kiro/skills/에 심링크하고 pin된 MCP 서버 버전으로 kiro-agents 프로파일을 연결합니다.",
+    "description": "Body text for Kiro integration"
+  },
+  "landing.integration.shared_state.title": {
+    "message": "공유 .omao 상태",
+    "description": "Title for shared state integration"
+  },
+  "landing.integration.shared_state.body": {
+    "message": "Tier-0 모드, 프로젝트 메모리, 감사 로그는 .omao/에 저장됩니다. 두 하네스 모두 동일한 디렉터리를 읽고 쓰므로 — 컨텍스트 손실 없이 전환 가능합니다.",
+    "description": "Body text for shared state integration"
+  },
+  "landing.faq.q1.q": {
+    "message": "이 리포지토리의 \"Tech Preview\"는 무엇을 의미하나요?",
+    "description": "FAQ question 1"
+  },
+  "landing.faq.q1.a": {
+    "message": "profile.yaml v1과 8개 온톨로지 스키마는 안정적입니다. CLI 표면과 doctor 리포트 형식은 GA 이전에 변경될 수 있습니다. Breaking 변경 사항은 CHANGELOG의 명시적 \"Breaking\" 제목 아래에 기록됩니다. 전체 안정성 계약은 지원 정책을 참조하세요.",
+    "description": "FAQ answer 1"
+  },
+  "landing.faq.q2.q": {
+    "message": "Claude Code와 Kiro를 둘 다 사용해야 하나요?",
+    "description": "FAQ question 2"
+  },
+  "landing.faq.q2.a": {
+    "message": "아니요. 하나를 선택하세요. 플러그인 디렉터리, 스킬, MCP 서버 pin은 하네스 간 동일하며 설치 스크립트만 다릅니다. .omao/ 상태 디렉터리는 하네스 독립적이므로 작업 손실 없이 나중에 전환할 수 있습니다.",
+    "description": "FAQ answer 2"
+  },
+  "landing.faq.q3.q": {
+    "message": "기본 워크플로우를 실행하는 데 필요한 AWS 권한은 무엇인가요?",
+    "description": "FAQ question 3"
+  },
+  "landing.faq.q3.a": {
+    "message": "EKS MCP 서버는 기본적으로 읽기 전용으로 실행됩니다 (--allow-write 없음). /oma:platform-bootstrap는 클러스터 계정에 대해 eks:*, ec2:*, iam:CreateRole이 필요합니다. /oma:agenticops는 CloudWatch, Prometheus, Cost Explorer를 읽습니다. 자격 증명은 셸 밖으로 수집되거나 전송되지 않습니다.",
+    "description": "FAQ answer 3"
+  },
+  "landing.faq.q4.q": {
+    "message": "OMA는 awslabs/aidlc-workflows와 어떤 관계인가요?",
+    "description": "FAQ question 4"
+  },
+  "landing.faq.q4.a": {
+    "message": "OMA는 aidlc-workflows를 핵심 AIDLC 스펙으로 사용하고 *.opt-in.md 확장 파일만 기여합니다. 핵심 워크플로우는 fork하지 않습니다. scripts/install/aidlc-extensions.sh가 런타임에 clone하고 opt-in 오버레이를 심링크합니다.",
+    "description": "FAQ answer 4"
+  },
+  "landing.faq.q5.q": {
+    "message": "/oma:agenticops를 켜면 비용은 어떻게 되나요?",
+    "description": "FAQ question 5"
+  },
+  "landing.faq.q5.a": {
+    "message": "cost-governance는 에이전트별 지출을 귀속시키고 Budget.action_on_breach를 통해 월간 한도를 강제합니다. 한도에 도달하면 모델 다운그레이드 PR (Opus → Sonnet → Haiku)을 작성하고 승인될 때까지 배포를 거부합니다. 명시적 승인 체인 없이는 자율 스케일링이 발생하지 않습니다.",
+    "description": "FAQ answer 5"
+  },
+  "landing.hero.eyebrow": {
+    "message": "aws-samples · AIDLC × AgenticOps",
+    "description": "Hero eyebrow text"
+  },
+  "landing.hero.preview_badge": {
+    "message": "Tech Preview",
+    "description": "Tech preview badge label"
+  },
+  "landing.hero.preview_text": {
+    "message": "v0.4.0-preview.1 — 스키마 및 DSL은 GA 이전에 변경될 수 있습니다.",
+    "description": "Tech preview description text"
+  },
+  "landing.hero.support_policy_link": {
+    "message": "지원 정책",
+    "description": "Support policy link text"
+  },
+  "landing.hero.title_line1": {
+    "message": "AIDLC 운영 공백은",
+    "description": "Hero main title line 1"
+  },
+  "landing.hero.title_line2_before": {
+    "message": "여전히",
+    "description": "Hero title line 2 before accent"
+  },
+  "landing.hero.title_line2_accent": {
+    "message": "사람의 손입니다.",
+    "description": "Hero title line 2 accent text"
+  },
+  "landing.hero.lede": {
+    "message": "AIDLC는 설계와 구축을 자동화합니다. 운영 — 배포, 인시던트, 비용 편차, 회귀 — 은 여전히 팀의 몫입니다. OMA는 AgenticOps로 루프를 닫는 플러그인 마켓플레이스입니다: 사람은 승인하고, 에이전트가 체크포인트 사이의 모든 것을 실행합니다.",
+    "description": "Hero lead paragraph"
+  },
+  "landing.hero.cta_primary": {
+    "message": "30초 안에 설치",
+    "description": "Primary CTA button text"
+  },
+  "landing.hero.cta_secondary": {
+    "message": "GitHub에서 Star",
+    "description": "Secondary CTA button text"
+  },
+  "landing.hero.stat1_label": {
+    "message": "플러그인",
+    "description": "Stat 1 label"
+  },
+  "landing.hero.stat2_label": {
+    "message": "Tier-0 워크플로우",
+    "description": "Stat 2 label"
+  },
+  "landing.hero.stat3_label": {
+    "message": "AWS MCP 서버",
+    "description": "Stat 3 label"
+  },
+  "landing.hero.stat3_value": {
+    "message": "11개 pin",
+    "description": "Stat 3 value"
+  },
+  "landing.hero.stat4_label": {
+    "message": "온톨로지 엔티티",
+    "description": "Stat 4 label"
+  },
+  "landing.hero.stat4_value": {
+    "message": "8개 스키마",
+    "description": "Stat 4 value"
+  },
+  "landing.hero.mock_callout": {
+    "message": "OMA · Inception → Construction → Operations. 승인 게이트: 4. 사이의 에이전트 단계: ~40.",
+    "description": "Hero mock terminal callout text"
+  },
+  "landing.contrast.kicker": {
+    "message": "공백",
+    "description": "Contrast section kicker"
+  },
+  "landing.contrast.title": {
+    "message": "대부분의 AIDLC 구현은 머지 시점에서 멈춥니다.",
+    "description": "Contrast section title"
+  },
+  "landing.contrast.without_title": {
+    "message": "OMA 없이",
+    "description": "Without OMA heading"
+  },
+  "landing.contrast.without_bullet1": {
+    "message": "트레이스는 Langfuse에 쌓이지만 PR이 되지 않습니다.",
+    "description": "Without OMA bullet 1"
+  },
+  "landing.contrast.without_bullet2": {
+    "message": "인시던트 플레이북은 새벽 2시에 on-call이 읽지 않는 위키에 있습니다.",
+    "description": "Without OMA bullet 2"
+  },
+  "landing.contrast.without_bullet3": {
+    "message": "비용 이상치는 다음 달 청구서에서 드러납니다.",
+    "description": "Without OMA bullet 3"
+  },
+  "landing.contrast.without_bullet4": {
+    "message": "모든 운영 결정은 사람의 판단입니다.",
+    "description": "Without OMA bullet 4"
+  },
+  "landing.contrast.with_title": {
+    "message": "OMA와 함께",
+    "description": "With OMA heading"
+  },
+  "landing.contrast.with_bullet1": {
+    "message": "트레이스 패턴은 이를 야기한 스킬에 대한 초안 PR을 엽니다 (Langfuse trace MCP를 구성하면).",
+    "description": "With OMA bullet 1"
+  },
+  "landing.contrast.with_bullet2": {
+    "message": "SEV1 알람은 인간 승인 게이트와 함께 진단 + 완화됩니다.",
+    "description": "With OMA bullet 2"
+  },
+  "landing.contrast.with_bullet3": {
+    "message": "예산 위반은 한도에 도달하기 전에 조절하거나 다운그레이드합니다.",
+    "description": "With OMA bullet 3"
+  },
+  "landing.contrast.with_bullet4": {
+    "message": "사람은 체크포인트에서 승인합니다. 에이전트가 나머지를 처리합니다.",
+    "description": "With OMA bullet 4"
+  },
+  "landing.superpowers.kicker": {
+    "message": "무엇이 바뀌는가",
+    "description": "Superpowers section kicker"
+  },
+  "landing.superpowers.title": {
+    "message": "AIDLC가 스스로 닫히게 만드는 세 가지 메커니즘.",
+    "description": "Superpowers section title"
+  },
+  "landing.integration.kicker": {
+    "message": "드롭인",
+    "description": "Integration section kicker"
+  },
+  "landing.integration.title": {
+    "message": "이미 사용 중인 도구 안에서 플러그인으로 제공됩니다.",
+    "description": "Integration section title"
+  },
+  "landing.loop.title": {
+    "message": "닫힌 AIDLC 루프.",
+    "description": "AIDLC loop section title"
+  },
+  "landing.loop.lede_before_em": {
+    "message": "Inception과 Construction은",
+    "description": "AIDLC loop lead paragraph before emphasis"
+  },
+  "landing.loop.lede_em": {
+    "message": "무엇을",
+    "description": "AIDLC loop lead paragraph emphasis"
+  },
+  "landing.loop.lede_after_em": {
+    "message": "출시할지 정의합니다. Operations는 출시 후 살아 있게 유지하며 — 일상적 수정을 위해 사람 없이 학습을 Construction으로 피드백합니다.",
+    "description": "AIDLC loop lead paragraph after emphasis"
+  },
+  "landing.loop.step1_title": {
+    "message": "Inception",
+    "description": "Loop step 1 title"
+  },
+  "landing.loop.step1_body": {
+    "message": "워크스페이스 탐지, 적응형 요구사항, 사용자 스토리, 워크플로우 계획. 출력 산출물은 Construction이 준수해야 할 계약이 됩니다.",
+    "description": "Loop step 1 body"
+  },
+  "landing.loop.step2_title": {
+    "message": "Construction",
+    "description": "Loop step 2 title"
+  },
+  "landing.loop.step2_body": {
+    "message": "컴포넌트 설계, 인간 승인 게이트가 있는 코드 생성, 12개 범주 리스크 발견, 에이전틱 시스템을 위한 TDD, 단계 품질 게이트.",
+    "description": "Loop step 2 body"
+  },
+  "landing.loop.step3_title": {
+    "message": "Operations",
+    "description": "Loop step 3 title"
+  },
+  "landing.loop.step3_body": {
+    "message": "Autopilot 배포, 지속적 평가, 인시던트 대응, 비용 거버넌스, 그리고 학습을 Construction으로 피드백하는 자가 개선 루프.",
+    "description": "Loop step 3 body"
+  },
+  "landing.loop.footer_before_ai_infra": {
+    "message": "런타임 (",
+    "description": "AIDLC loop footer before ai-infra"
+  },
+  "landing.loop.footer_between": {
+    "message": ")과 브라운필드 진입 (",
+    "description": "AIDLC loop footer between code blocks"
+  },
+  "landing.loop.footer_after_modernization": {
+    "message": ")은 루프 내부가 아닌 옆에 위치합니다.",
+    "description": "AIDLC loop footer after modernization"
+  },
+  "landing.capabilities.kicker": {
+    "message": "AgenticOps 역량",
+    "description": "Capabilities section kicker"
+  },
+  "landing.capabilities.title": {
+    "message": "자율 시대를 위해 설계되었습니다.",
+    "description": "Capabilities section title"
+  },
+  "landing.workflows.kicker": {
+    "message": "9개 Tier-0 워크플로우",
+    "description": "Workflows section kicker"
+  },
+  "landing.workflows.title": {
+    "message": "슬래시 커맨드 하나를 호출하면 체크포인트가 있는 계획을 얻습니다.",
+    "description": "Workflows section title"
+  },
+  "landing.workflows.footer": {
+    "message": "키워드 트리거는 프롬프트에 매치가 포함되면 적절한 커맨드를 자동 제안합니다.",
+    "description": "Workflows footer text"
+  },
+  "landing.workflows.trigger_catalog_link": {
+    "message": "트리거 카탈로그",
+    "description": "Trigger catalog link text"
+  },
+  "landing.plugins.kicker": {
+    "message": "4개 플러그인",
+    "description": "Plugins section kicker"
+  },
+  "landing.plugins.title": {
+    "message": "필요한 것만 설치 — 또는 하나의 마켓플레이스 커맨드로 전체 4개.",
+    "description": "Plugins section title"
+  },
+  "landing.install.kicker": {
+    "message": "30초 설치",
+    "description": "Install section kicker"
+  },
+  "landing.install.title": {
+    "message": "터미널 세 줄로 작동하는 루프.",
+    "description": "Install section title"
+  },
+  "landing.install.step1_title": {
+    "message": "마켓플레이스 등록",
+    "description": "Install step 1 title"
+  },
+  "landing.install.step2_title": {
+    "message": "4개 플러그인 설치",
+    "description": "Install step 2 title"
+  },
+  "landing.install.step3_title": {
+    "message": "Tier-0 워크플로우 실행",
+    "description": "Install step 3 title"
+  },
+  "landing.install.hint": {
+    "message": "또는 더 안전한 진입로로 시작:",
+    "description": "Install hint text"
+  },
+  "landing.install.guide_link": {
+    "message": "getting-started 가이드",
+    "description": "Getting started guide link text"
+  },
+  "landing.security.kicker": {
+    "message": "기본 보안",
+    "description": "Security section kicker"
+  },
+  "landing.security.title": {
+    "message": "데모가 아닌 출시 준비.",
+    "description": "Security section title"
+  },
+  "landing.security.item1_title": {
+    "message": "MCP 버전 pin",
+    "description": "Security item 1 title"
+  },
+  "landing.security.item1_body": {
+    "message": "모든 .mcp.json과 에이전트 프로파일은 정확한 PyPI 버전으로 awslabs MCP 서버를 참조합니다. @latest 공급망 서프라이즈 없음.",
+    "description": "Security item 1 body"
+  },
+  "landing.security.item2_title": {
+    "message": "읽기 전용 EKS MCP",
+    "description": "Security item 2 title"
+  },
+  "landing.security.item2_body": {
+    "message": "Kiro 에이전트 프로파일은 기본적으로 --allow-write나 --allow-sensitive-data-access를 활성화하지 않습니다. 명시적으로 opt-in 하세요.",
+    "description": "Security item 2 body"
+  },
+  "landing.security.item3_title": {
+    "message": "최소 권한 IAM",
+    "description": "Security item 3 title"
+  },
+  "landing.security.item3_body": {
+    "message": "langfuse-observability는 버킷 범위 customer-managed 정책을 사용합니다. AmazonS3FullAccess는 Bad Example로 명시됩니다.",
+    "description": "Security item 3 body"
+  },
+  "landing.security.item4_title": {
+    "message": "샌드박싱된 표현식",
+    "description": "Security item 4 title"
+  },
+  "landing.security.item4_body": {
+    "message": "cost-governance는 simpleeval로 budget.yaml 규칙을 평가합니다. 사용자 편집 가능 설정에 Python eval()은 문서화된 RCE 벡터입니다.",
+    "description": "Security item 4 body"
+  },
+  "landing.security.item5_title": {
+    "message": "세션 상태는 로컬 유지",
+    "description": "Security item 5 title"
+  },
+  "landing.security.item5_body": {
+    "message": ".omao/state, .omao/plans, .omao/logs, audit-trail 출력, 프로젝트 메모리는 gitignore됩니다. Verbatim 프롬프트는 절대 머신을 떠나지 않습니다.",
+    "description": "Security item 5 body"
+  },
+  "landing.security.item6_title": {
+    "message": "안전한 JSON hook",
+    "description": "Security item 6 title"
+  },
+  "landing.security.item6_body": {
+    "message": "session-start.sh는 jq 또는 python3를 요구하며 셸 보간 JSON 출력을 거부해, 컨텍스트로의 state-file 인젝션을 방지합니다.",
+    "description": "Security item 6 body"
+  },
+  "landing.faq.kicker": {
+    "message": "FAQ",
+    "description": "FAQ section kicker"
+  },
+  "landing.faq.title": {
+    "message": "설치 전 자주 묻는 질문.",
+    "description": "FAQ section title"
+  },
+  "landing.cta.title": {
+    "message": "운영 루프를 손으로 돌리는 것을 멈추세요.",
+    "description": "Final CTA title"
+  },
+  "landing.cta.lede": {
+    "message": "한 번 설치하고, 체크포인트에서 승인하고, 에이전트가 AIDLC 루프의 나머지를 처리하게 하세요.",
+    "description": "Final CTA lead text"
+  },
+  "landing.cta.primary": {
+    "message": "getting-started 가이드 읽기",
+    "description": "Final CTA primary button"
+  },
+  "landing.cta.secondary": {
+    "message": "GitHub에서 Star",
+    "description": "Final CTA secondary button"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "페이지에 오류가 발생하였습니다.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "맨 위로 스크롤하기",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "게시물 목록",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "게시물 목록",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "블로그 게시물 목록 탐색",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "이전 페이지",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "다음 페이지",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "블로그 게시물 탐색",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "이전 게시물",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "다음 게시물",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "모든 태그 보기",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "밝은 모드",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "어두운 모드",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "어두운 모드와 밝은 모드 전환하기 (현재 {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "탐색 경로",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 항목",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "문서 페이지",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "이전",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "다음",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "버전: {versionLabel}"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count}개 문서가",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} \"{tagName}\" 태그에 분류되었습니다",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 아직 정식 공개되지 않았습니다.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 더 이상 업데이트되지 않습니다.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "최신 문서는 {latestVersionLink} ({versionLabel})을 확인하세요.",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "최신 버전",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "페이지 편집",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}에 대한 직접 링크",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " {date}에",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " {user}가",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "최종 수정: {atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.NotFound.title": {
+    "message": "페이지를 찾을 수 없습니다.",
+    "description": "The title of the 404 page"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "버전",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "태그:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "주의",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "위험",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "정보",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "노트",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "팁",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "경고",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "닫기",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "최근 블로그 문서 둘러보기",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 펼치기",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 접기",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NotFound.p1": {
+    "message": "원하는 페이지를 찾을 수 없습니다.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "사이트 관리자에게 링크가 깨진 것을 알려주세요.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "메인",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "이 페이지에서",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "언어",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "약 {readingTime}분",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "자세히 보기",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "{title} 에 대해 더 읽어보기",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "복사",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "복사했습니다",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "클립보드에 코드 복사",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "줄 바꿈 전환",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "홈",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "문서 사이드바",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "사이드바 닫기",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 메인 메뉴로 돌아가기",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "사이드바 펼치거나 접기",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count}개 게시물",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "\"{tagName}\" 태그로 연결된 {nPosts}개의 게시물이 있습니다.",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "저자",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "모든 저자 보기",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "작성자가 아직 게시글을 작성하지 않았습니다.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "색인되지 않은 문서",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "이 문서는 색인되지 않습니다. 검색 엔진이 이 문서를 색인하지 않으며, 주소를 알고 있는 사용자만 접근할 수 있습니다.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "작성 중인 페이지",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "이 페이지는 아직 작성 중입니다. 개발 환경에서만 보이며 프로덕션 빌드에서는 제외됩니다.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "다시 시도해 보세요",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "본문으로 건너뛰기",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "태그",
+    "description": "The title of the tag list page"
+  }
+}

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,50 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Reliability dual-axis": {
+    "message": "Reliability dual-axis",
+    "description": "The label for category 'Reliability dual-axis' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category 'Installation' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Foundation": {
+    "message": "Foundation",
+    "description": "The label for category 'Foundation' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Governance": {
+    "message": "Governance",
+    "description": "The label for category 'Governance' in sidebar 'docs'"
+  },
+  "sidebar.docs.link.Releases": {
+    "message": "Releases",
+    "description": "The label for link 'Releases' in sidebar 'docs', linking to '/releases'"
+  },
+  "sidebar.docs.doc.Introduction": {
+    "message": "Introduction",
+    "description": "The label for the doc item 'Introduction' in sidebar 'docs', linking to the doc intro"
+  },
+  "sidebar.docs.doc.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for the doc item 'Getting Started' in sidebar 'docs', linking to the doc getting-started"
+  },
+  "sidebar.docs.doc.Philosophy": {
+    "message": "Philosophy",
+    "description": "The label for the doc item 'Philosophy' in sidebar 'docs', linking to the doc philosophy-aidlc-meets-agenticops"
+  },
+  "sidebar.docs.doc.Tier-0 Workflows": {
+    "message": "Tier-0 Workflows",
+    "description": "The label for the doc item 'Tier-0 Workflows' in sidebar 'docs', linking to the doc tier-0-workflows"
+  },
+  "sidebar.docs.doc.Keyword Triggers": {
+    "message": "Keyword Triggers",
+    "description": "The label for the doc item 'Keyword Triggers' in sidebar 'docs', linking to the doc keyword-triggers"
+  },
+  "sidebar.docs.doc.Easy Button": {
+    "message": "Easy Button",
+    "description": "The label for the doc item 'Easy Button' in sidebar 'docs', linking to the doc easy-button"
+  }
+}

--- a/docs/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/ko/docusaurus-theme-classic/footer.json
@@ -1,0 +1,58 @@
+{
+  "link.title.Docs": {
+    "message": "문서",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Install": {
+    "message": "설치",
+    "description": "The title of the footer links column with title=Install in the footer"
+  },
+  "link.title.Project": {
+    "message": "프로젝트",
+    "description": "The title of the footer links column with title=Project in the footer"
+  },
+  "link.item.label.Introduction": {
+    "message": "소개",
+    "description": "The label of footer link with label=Introduction linking to /docs/intro"
+  },
+  "link.item.label.Getting Started": {
+    "message": "시작하기",
+    "description": "The label of footer link with label=Getting Started linking to /docs/getting-started"
+  },
+  "link.item.label.Tier-0 Workflows": {
+    "message": "Tier-0 워크플로우",
+    "description": "The label of footer link with label=Tier-0 Workflows linking to /docs/tier-0-workflows"
+  },
+  "link.item.label.Claude Code Setup": {
+    "message": "Claude Code 설정",
+    "description": "The label of footer link with label=Claude Code Setup linking to /docs/claude-code-setup"
+  },
+  "link.item.label.Kiro Setup": {
+    "message": "Kiro 설정",
+    "description": "The label of footer link with label=Kiro Setup linking to /docs/kiro-setup"
+  },
+  "link.item.label.Keyword Triggers": {
+    "message": "키워드 트리거",
+    "description": "The label of footer link with label=Keyword Triggers linking to /docs/keyword-triggers"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aws-samples/sample-oh-my-aidlcops"
+  },
+  "link.item.label.LICENSE (MIT-0)": {
+    "message": "LICENSE (MIT-0)",
+    "description": "The label of footer link with label=LICENSE (MIT-0) linking to https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/LICENSE"
+  },
+  "link.item.label.NOTICE": {
+    "message": "NOTICE",
+    "description": "The label of footer link with label=NOTICE linking to https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/NOTICE"
+  },
+  "link.item.label.oh-my-claudecode": {
+    "message": "oh-my-claudecode",
+    "description": "The label of footer link with label=oh-my-claudecode linking to https://github.com/Yeachan-Heo/oh-my-claudecode"
+  },
+  "copyright": {
+    "message": "Copyright 2026 Amazon.com, Inc. or its affiliates. MIT-0 licensed.",
+    "description": "The footer copyright"
+  }
+}

--- a/docs/i18n/ko/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/ko/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "message": "OMA",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "oh-my-aidlcops",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "문서",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Workflows": {
+    "message": "워크플로우",
+    "description": "Navbar item with label Workflows"
+  },
+  "item.label.Triggers": {
+    "message": "트리거",
+    "description": "Navbar item with label Triggers"
+  },
+  "item.label.Ontology": {
+    "message": "온톨로지",
+    "description": "Navbar item with label Ontology"
+  },
+  "item.label.DSL": {
+    "message": "DSL",
+    "description": "Navbar item with label DSL"
+  },
+  "item.label.Easy Button": {
+    "message": "이지버튼",
+    "description": "Navbar item with label Easy Button"
+  },
+  "item.label.Star": {
+    "message": "Star",
+    "description": "Navbar item with label Star"
+  }
+}

--- a/docs/src/components/HomeLanding/index.tsx
+++ b/docs/src/components/HomeLanding/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Translate, { translate } from '@docusaurus/Translate';
 import styles from './styles.module.css';
 
 type Plugin = {
@@ -13,33 +14,65 @@ type Plugin = {
 const PLUGINS: Plugin[] = [
   {
     name: 'ai-infra',
-    tagline: 'Build the runtime.',
-    scope:
-      'AI runtime infrastructure on AWS. Ships EKS + vLLM + Inference Gateway + Langfuse + GPU + guardrails today; Bedrock / SageMaker runtime skills planned. MCP servers pinned to exact PyPI versions — no @latest.',
+    tagline: translate({
+      id: 'landing.plugin.ai_infra.tagline',
+      message: 'Build the runtime.',
+      description: 'Tagline for ai-infra plugin',
+    }),
+    scope: translate({
+      id: 'landing.plugin.ai_infra.scope',
+      message:
+        'AI runtime infrastructure on AWS. Ships EKS + vLLM + Inference Gateway + Langfuse + GPU + guardrails today; Bedrock / SageMaker runtime skills planned. MCP servers pinned to exact PyPI versions — no @latest.',
+      description: 'Description of ai-infra plugin scope',
+    }),
     skills:
       'agentic-eks-bootstrap · vllm-serving-setup · inference-gateway-routing · langfuse-observability · gpu-resource-management · ai-gateway-guardrails',
   },
   {
     name: 'aidlc',
-    tagline: 'Design and build with a spec.',
-    scope:
-      'AIDLC Phase 1 (Inception) + Phase 2 (Construction) opt-in extensions for awslabs/aidlc-workflows. Inception captures workspace, requirements, stories, and the workflow plan. Construction turns that plan into components, code, tests, and risk-discovered quality gates.',
+    tagline: translate({
+      id: 'landing.plugin.aidlc.tagline',
+      message: 'Design and build with a spec.',
+      description: 'Tagline for aidlc plugin',
+    }),
+    scope: translate({
+      id: 'landing.plugin.aidlc.scope',
+      message:
+        'AIDLC Phase 1 (Inception) + Phase 2 (Construction) opt-in extensions for awslabs/aidlc-workflows. Inception captures workspace, requirements, stories, and the workflow plan. Construction turns that plan into components, code, tests, and risk-discovered quality gates.',
+      description: 'Description of aidlc plugin scope',
+    }),
     skills:
       'workspace-detection · requirements-analysis · user-stories · workflow-planning · component-design · code-generation · test-strategy · risk-discovery · quality-gates',
   },
   {
     name: 'agenticops',
-    tagline: 'Operate with agents.',
-    scope:
-      'Autonomous operations for production agentic workloads. Incident response, self-improving feedback loops, progressive rollouts with SLO circuit breakers, cost governance with a simpleeval sandbox, and verbatim audit trails.',
+    tagline: translate({
+      id: 'landing.plugin.agenticops.tagline',
+      message: 'Operate with agents.',
+      description: 'Tagline for agenticops plugin',
+    }),
+    scope: translate({
+      id: 'landing.plugin.agenticops.scope',
+      message:
+        'Autonomous operations for production agentic workloads. Incident response, self-improving feedback loops, progressive rollouts with SLO circuit breakers, cost governance with a simpleeval sandbox, and verbatim audit trails.',
+      description: 'Description of agenticops plugin scope',
+    }),
     skills:
       'self-improving-loop · autopilot-deploy · incident-response · continuous-eval · cost-governance · audit-trail',
   },
   {
     name: 'modernization',
-    tagline: 'Lift legacy onto AWS.',
-    scope:
-      'Brownfield legacy workload modernization using the AWS 6R strategy. Workload assessment with Five Lenses, 6R decision matrix, to-be architecture, containerization hardening, and production cutover planning with rollback triggers.',
+    tagline: translate({
+      id: 'landing.plugin.modernization.tagline',
+      message: 'Lift legacy onto AWS.',
+      description: 'Tagline for modernization plugin',
+    }),
+    scope: translate({
+      id: 'landing.plugin.modernization.scope',
+      message:
+        'Brownfield legacy workload modernization using the AWS 6R strategy. Workload assessment with Five Lenses, 6R decision matrix, to-be architecture, containerization hardening, and production cutover planning with rollback triggers.',
+      description: 'Description of modernization plugin scope',
+    }),
     skills:
       'workload-assessment · modernization-strategy · to-be-architecture · containerization · cutover-planning',
   },
@@ -55,68 +88,128 @@ const WORKFLOWS: Workflow[] = [
   {
     keyword: 'autopilot',
     command: '/oma:autopilot',
-    scope: 'Full AIDLC loop (Inception → Construction → Operations).',
+    scope: translate({
+      id: 'landing.workflow.autopilot.scope',
+      message: 'Full AIDLC loop (Inception → Construction → Operations).',
+      description: 'Description of autopilot workflow',
+    }),
   },
   {
     keyword: 'aidlc-loop',
     command: '/oma:aidlc-loop',
-    scope: 'Single-feature Inception → Construction pass.',
+    scope: translate({
+      id: 'landing.workflow.aidlc_loop.scope',
+      message: 'Single-feature Inception → Construction pass.',
+      description: 'Description of aidlc-loop workflow',
+    }),
   },
   {
     keyword: 'inception',
     command: '/oma:inception',
-    scope: 'AIDLC Phase 1 only — spec, stories, workflow plan.',
+    scope: translate({
+      id: 'landing.workflow.inception.scope',
+      message: 'AIDLC Phase 1 only — spec, stories, workflow plan.',
+      description: 'Description of inception workflow',
+    }),
   },
   {
     keyword: 'construction',
     command: '/oma:construction',
-    scope: 'AIDLC Phase 2 only — design, codegen, agentic TDD.',
+    scope: translate({
+      id: 'landing.workflow.construction.scope',
+      message: 'AIDLC Phase 2 only — design, codegen, agentic TDD.',
+      description: 'Description of construction workflow',
+    }),
   },
   {
     keyword: 'agenticops',
     command: '/oma:agenticops',
-    scope: 'Operations mode: continuous-eval + incident-response + cost-governance.',
+    scope: translate({
+      id: 'landing.workflow.agenticops.scope',
+      message: 'Operations mode: continuous-eval + incident-response + cost-governance.',
+      description: 'Description of agenticops workflow',
+    }),
   },
   {
     keyword: 'self-improving',
     command: '/oma:self-improving',
-    scope: 'Langfuse traces (via your configured trace MCP) → prompt / skill improvement PR.',
+    scope: translate({
+      id: 'landing.workflow.self_improving.scope',
+      message: 'Langfuse traces (via your configured trace MCP) → prompt / skill improvement PR.',
+      description: 'Description of self-improving workflow',
+    }),
   },
   {
     keyword: 'platform-bootstrap',
     command: '/oma:platform-bootstrap',
-    scope: '5-checkpoint Agentic AI Platform bootstrap on EKS.',
+    scope: translate({
+      id: 'landing.workflow.platform_bootstrap.scope',
+      message: '5-checkpoint Agentic AI Platform bootstrap on EKS.',
+      description: 'Description of platform-bootstrap workflow',
+    }),
   },
   {
     keyword: 'modernize',
     command: '/oma:modernize',
-    scope: '6-stage brownfield modernization (assessment → cutover).',
+    scope: translate({
+      id: 'landing.workflow.modernize.scope',
+      message: '6-stage brownfield modernization (assessment → cutover).',
+      description: 'Description of modernize workflow',
+    }),
   },
   {
     keyword: 'cancel',
     command: '/oma:cancel',
-    scope: 'Terminate the active Tier-0 mode.',
+    scope: translate({
+      id: 'landing.workflow.cancel.scope',
+      message: 'Terminate the active Tier-0 mode.',
+      description: 'Description of cancel workflow',
+    }),
   },
 ];
 
 const SUPERPOWERS = [
   {
     num: '01',
-    title: 'One command, entire lifecycle.',
-    body:
-      'Spec → design → code → canary deploy → self-healing → cost attribution. /oma:autopilot drives the whole loop and pauses only at explicit approval checkpoints.',
+    title: translate({
+      id: 'landing.superpower.1.title',
+      message: 'One command, entire lifecycle.',
+      description: 'Title for superpower 1',
+    }),
+    body: translate({
+      id: 'landing.superpower.1.body',
+      message:
+        'Spec → design → code → canary deploy → self-healing → cost attribution. /oma:autopilot drives the whole loop and pauses only at explicit approval checkpoints.',
+      description: 'Body text for superpower 1',
+    }),
   },
   {
     num: '02',
-    title: 'Self-improving from production traces.',
-    body:
-      'When you configure your own Langfuse + trace-reading MCP (via profile observability.trace_mcp), traces feed /oma:self-improving. Failure patterns become draft PRs against the skills and prompts that produced them — regression tests run before the PR is opened.',
+    title: translate({
+      id: 'landing.superpower.2.title',
+      message: 'Self-improving from production traces.',
+      description: 'Title for superpower 2',
+    }),
+    body: translate({
+      id: 'landing.superpower.2.body',
+      message:
+        'When you configure your own Langfuse + trace-reading MCP (via profile observability.trace_mcp), traces feed /oma:self-improving. Failure patterns become draft PRs against the skills and prompts that produced them — regression tests run before the PR is opened.',
+      description: 'Body text for superpower 2',
+    }),
   },
   {
     num: '03',
-    title: 'Humans approve. Agents execute.',
-    body:
-      'Every Tier-0 workflow sandwiches agent-driven diagnosis, proposal, and execution between explicit human gates. The agent never silently mutates production.',
+    title: translate({
+      id: 'landing.superpower.3.title',
+      message: 'Humans approve. Agents execute.',
+      description: 'Title for superpower 3',
+    }),
+    body: translate({
+      id: 'landing.superpower.3.body',
+      message:
+        'Every Tier-0 workflow sandwiches agent-driven diagnosis, proposal, and execution between explicit human gates. The agent never silently mutates production.',
+      description: 'Body text for superpower 3',
+    }),
   },
 ];
 
@@ -131,31 +224,79 @@ type Capability = {
 
 const CAPABILITIES: Capability[] = [
   {
-    title: 'Autopilot deploys',
-    body:
-      'autopilot-deploy runs canary 1% → 10% → 50% → 100% with SLO-gated circuit breakers. Each stage waits for continuous-eval before promotion; regression trips auto-rollback.',
+    title: translate({
+      id: 'landing.capability.autopilot.title',
+      message: 'Autopilot deploys',
+      description: 'Title for autopilot deploys capability',
+    }),
+    body: translate({
+      id: 'landing.capability.autopilot.body',
+      message:
+        'autopilot-deploy runs canary 1% → 10% → 50% → 100% with SLO-gated circuit breakers. Each stage waits for continuous-eval before promotion; regression trips auto-rollback.',
+      description: 'Body text for autopilot deploys capability',
+    }),
     icon: 'rocket',
     variant: 'wide',
-    bullets: ['Argo Rollouts / Flagger', 'Prometheus SLO gates', 'Human approval at 100%'],
+    bullets: [
+      translate({
+        id: 'landing.capability.autopilot.bullet1',
+        message: 'Argo Rollouts / Flagger',
+        description: 'First bullet for autopilot deploys',
+      }),
+      translate({
+        id: 'landing.capability.autopilot.bullet2',
+        message: 'Prometheus SLO gates',
+        description: 'Second bullet for autopilot deploys',
+      }),
+      translate({
+        id: 'landing.capability.autopilot.bullet3',
+        message: 'Human approval at 100%',
+        description: 'Third bullet for autopilot deploys',
+      }),
+    ],
   },
   {
-    title: 'Self-healing',
-    body:
-      'incident-response classifies SEV1–4, pulls the matching runbook, issues diagnostic MCP queries, and drafts a remediation script for approval. SEV1 pages on-call; it never acts.',
+    title: translate({
+      id: 'landing.capability.self_healing.title',
+      message: 'Self-healing',
+      description: 'Title for self-healing capability',
+    }),
+    body: translate({
+      id: 'landing.capability.self_healing.body',
+      message:
+        'incident-response classifies SEV1–4, pulls the matching runbook, issues diagnostic MCP queries, and drafts a remediation script for approval. SEV1 pages on-call; it never acts.',
+      description: 'Body text for self-healing capability',
+    }),
     icon: 'shield',
     variant: 'accent',
   },
   {
-    title: 'Cost governance',
-    body:
-      'cost-governance attributes spend per agent, vetoes deploys that would breach the monthly ceiling, and drafts Opus → Sonnet → Haiku downgrade PRs. budget.yaml runs in a simpleeval sandbox — no Python eval, no RCE vector.',
+    title: translate({
+      id: 'landing.capability.cost_governance.title',
+      message: 'Cost governance',
+      description: 'Title for cost governance capability',
+    }),
+    body: translate({
+      id: 'landing.capability.cost_governance.body',
+      message:
+        'cost-governance attributes spend per agent, vetoes deploys that would breach the monthly ceiling, and drafts Opus → Sonnet → Haiku downgrade PRs. budget.yaml runs in a simpleeval sandbox — no Python eval, no RCE vector.',
+      description: 'Body text for cost governance capability',
+    }),
     icon: 'coin',
     variant: 'quiet',
   },
   {
-    title: 'CLI first. Always.',
-    body:
-      'Every skill is reachable as a slash command in Claude Code or a direct skill call in Kiro. The full state lives under .omao/ and is portable between harnesses.',
+    title: translate({
+      id: 'landing.capability.cli_first.title',
+      message: 'CLI first. Always.',
+      description: 'Title for CLI first capability',
+    }),
+    body: translate({
+      id: 'landing.capability.cli_first.body',
+      message:
+        'Every skill is reachable as a slash command in Claude Code or a direct skill call in Kiro. The full state lives under .omao/ and is portable between harnesses.',
+      description: 'Body text for CLI first capability',
+    }),
     icon: 'terminal',
     variant: 'terminal',
     code: [
@@ -170,45 +311,114 @@ const CAPABILITIES: Capability[] = [
 
 const INTEGRATIONS = [
   {
-    title: 'Claude Code plugin',
+    title: translate({
+      id: 'landing.integration.claude_code.title',
+      message: 'Claude Code plugin',
+      description: 'Title for Claude Code integration',
+    }),
     icon: 'plug',
-    body:
-      'Ship as a native Claude Code marketplace entry. Slash commands, keyword triggers, and the AWS hosted MCP layer work out of the box.',
+    body: translate({
+      id: 'landing.integration.claude_code.body',
+      message:
+        'Ship as a native Claude Code marketplace entry. Slash commands, keyword triggers, and the AWS hosted MCP layer work out of the box.',
+      description: 'Body text for Claude Code integration',
+    }),
   },
   {
-    title: 'Kiro skills',
+    title: translate({
+      id: 'landing.integration.kiro.title',
+      message: 'Kiro skills',
+      description: 'Title for Kiro integration',
+    }),
     icon: 'spark',
-    body:
-      'install/kiro.sh symlinks every skill into ~/.kiro/skills/ and wires kiro-agents profiles with pinned MCP server versions.',
+    body: translate({
+      id: 'landing.integration.kiro.body',
+      message:
+        'install/kiro.sh symlinks every skill into ~/.kiro/skills/ and wires kiro-agents profiles with pinned MCP server versions.',
+      description: 'Body text for Kiro integration',
+    }),
   },
   {
-    title: 'Shared .omao state',
+    title: translate({
+      id: 'landing.integration.shared_state.title',
+      message: 'Shared .omao state',
+      description: 'Title for shared state integration',
+    }),
     icon: 'layers',
-    body:
-      'Tier-0 mode, project memory, and audit logs live in .omao/. Both harnesses read and write the same directory — switch without losing context.',
+    body: translate({
+      id: 'landing.integration.shared_state.body',
+      message:
+        'Tier-0 mode, project memory, and audit logs live in .omao/. Both harnesses read and write the same directory — switch without losing context.',
+      description: 'Body text for shared state integration',
+    }),
   },
 ];
 
 const FAQ = [
   {
-    q: 'What does "Tech Preview" mean for this repo?',
-    a: 'profile.yaml v1 and the 8 ontology schemas are stable; CLI surfaces and the doctor report shape may still evolve before GA. Breaking changes land in CHANGELOG under an explicit "Breaking" heading. See the support policy for the full stability contract.',
+    q: translate({
+      id: 'landing.faq.q1.q',
+      message: 'What does "Tech Preview" mean for this repo?',
+      description: 'FAQ question 1',
+    }),
+    a: translate({
+      id: 'landing.faq.q1.a',
+      message:
+        'profile.yaml v1 and the 8 ontology schemas are stable; CLI surfaces and the doctor report shape may still evolve before GA. Breaking changes land in CHANGELOG under an explicit "Breaking" heading. See the support policy for the full stability contract.',
+      description: 'FAQ answer 1',
+    }),
   },
   {
-    q: 'Do I have to use both Claude Code and Kiro?',
-    a: 'No. Pick one. The plugin directory, skills, and MCP server pinning are identical across harnesses; only the install script differs. The .omao/ state directory is harness-agnostic, so you can switch later without losing work.',
+    q: translate({
+      id: 'landing.faq.q2.q',
+      message: 'Do I have to use both Claude Code and Kiro?',
+      description: 'FAQ question 2',
+    }),
+    a: translate({
+      id: 'landing.faq.q2.a',
+      message:
+        'No. Pick one. The plugin directory, skills, and MCP server pinning are identical across harnesses; only the install script differs. The .omao/ state directory is harness-agnostic, so you can switch later without losing work.',
+      description: 'FAQ answer 2',
+    }),
   },
   {
-    q: 'What AWS permissions do I need to run the default workflows?',
-    a: 'The EKS MCP server runs read-only by default (no --allow-write). /oma:platform-bootstrap needs eks:*, ec2:*, and iam:CreateRole against your cluster account. /oma:agenticops reads CloudWatch, Prometheus, and Cost Explorer. No credentials are collected or sent anywhere beyond your shell.',
+    q: translate({
+      id: 'landing.faq.q3.q',
+      message: 'What AWS permissions do I need to run the default workflows?',
+      description: 'FAQ question 3',
+    }),
+    a: translate({
+      id: 'landing.faq.q3.a',
+      message:
+        'The EKS MCP server runs read-only by default (no --allow-write). /oma:platform-bootstrap needs eks:*, ec2:*, and iam:CreateRole against your cluster account. /oma:agenticops reads CloudWatch, Prometheus, and Cost Explorer. No credentials are collected or sent anywhere beyond your shell.',
+      description: 'FAQ answer 3',
+    }),
   },
   {
-    q: 'How does OMA relate to awslabs/aidlc-workflows?',
-    a: 'OMA consumes aidlc-workflows as the core AIDLC spec and contributes only *.opt-in.md extension files into it. We do not fork the core workflow. scripts/install/aidlc-extensions.sh clones it at runtime and symlinks our opt-in overlays.',
+    q: translate({
+      id: 'landing.faq.q4.q',
+      message: 'How does OMA relate to awslabs/aidlc-workflows?',
+      description: 'FAQ question 4',
+    }),
+    a: translate({
+      id: 'landing.faq.q4.a',
+      message:
+        'OMA consumes aidlc-workflows as the core AIDLC spec and contributes only *.opt-in.md extension files into it. We do not fork the core workflow. scripts/install/aidlc-extensions.sh clones it at runtime and symlinks our opt-in overlays.',
+      description: 'FAQ answer 4',
+    }),
   },
   {
-    q: 'What happens to cost when I turn on /oma:agenticops?',
-    a: 'cost-governance attributes spend per agent and enforces a monthly ceiling via Budget.action_on_breach. When the ceiling is in reach it drafts model-downgrade PRs (Opus → Sonnet → Haiku) and vetoes deploys until approved. No autonomous scaling happens without an explicit approval chain.',
+    q: translate({
+      id: 'landing.faq.q5.q',
+      message: 'What happens to cost when I turn on /oma:agenticops?',
+      description: 'FAQ question 5',
+    }),
+    a: translate({
+      id: 'landing.faq.q5.a',
+      message:
+        'cost-governance attributes spend per agent and enforces a monthly ceiling via Budget.action_on_breach. When the ceiling is in reach it drafts model-downgrade PRs (Opus → Sonnet → Haiku) and vetoes deploys until approved. No autonomous scaling happens without an explicit approval chain.',
+      description: 'FAQ answer 5',
+    }),
   },
 ];
 
@@ -320,28 +530,54 @@ export default function HomeLanding(): React.ReactElement {
           <div className={styles.heroCopy}>
             <div className={styles.eyebrow}>
               <span className={styles.eyebrowDot} aria-hidden="true" />
-              aws-samples · AIDLC × AgenticOps
+              <Translate id="landing.hero.eyebrow" description="Hero eyebrow text">
+                aws-samples · AIDLC × AgenticOps
+              </Translate>
             </div>
             <div className={styles.previewBadge} role="note">
-              <span className={styles.previewBadgeLabel}>Tech Preview</span>
+              <span className={styles.previewBadgeLabel}>
+                <Translate id="landing.hero.preview_badge" description="Tech preview badge label">
+                  Tech Preview
+                </Translate>
+              </span>
               <span className={styles.previewBadgeText}>
-                v0.4.0-preview.1 — schemas &amp; DSL may change before GA. See the{' '}
-                <Link to={useBaseUrl('/docs/support-policy')}>support policy</Link>.
+                <Translate id="landing.hero.preview_text" description="Tech preview description text">
+                  v0.4.0-preview.1 — schemas &amp; DSL may change before GA. See the
+                </Translate>{' '}
+                <Link to={useBaseUrl('/docs/support-policy')}>
+                  <Translate id="landing.hero.support_policy_link" description="Support policy link text">
+                    support policy
+                  </Translate>
+                </Link>.
               </span>
             </div>
             <h1 className={styles.heroTitle}>
-              The AIDLC operations gap<br />
-              is still <span className={styles.accent}>human glue.</span>
+              <Translate id="landing.hero.title_line1" description="Hero main title line 1">
+                The AIDLC operations gap
+              </Translate>
+              <br />
+              <Translate id="landing.hero.title_line2_before" description="Hero title line 2 before accent">
+                is still
+              </Translate>{' '}
+              <span className={styles.accent}>
+                <Translate id="landing.hero.title_line2_accent" description="Hero title line 2 accent text">
+                  human glue.
+                </Translate>
+              </span>
             </h1>
             <p className={styles.heroLede}>
-              AIDLC automates design and construction. Operations — deploys, incidents, cost
-              drift, regressions — still fall on the team. OMA is the plugin marketplace that
-              closes the loop with AgenticOps: humans approve, agents execute everything
-              between the checkpoints.
+              <Translate id="landing.hero.lede" description="Hero lead paragraph">
+                AIDLC automates design and construction. Operations — deploys, incidents, cost
+                drift, regressions — still fall on the team. OMA is the plugin marketplace that
+                closes the loop with AgenticOps: humans approve, agents execute everything
+                between the checkpoints.
+              </Translate>
             </p>
             <div className={styles.heroCtaRow}>
               <Link className={styles.ctaPrimary} to={useBaseUrl('/docs/getting-started')}>
-                Install in 30 seconds
+                <Translate id="landing.hero.cta_primary" description="Primary CTA button text">
+                  Install in 30 seconds
+                </Translate>
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
@@ -352,25 +588,51 @@ export default function HomeLanding(): React.ReactElement {
                 target="_blank"
                 rel="noreferrer"
               >
-                Star on GitHub
+                <Translate id="landing.hero.cta_secondary" description="Secondary CTA button text">
+                  Star on GitHub
+                </Translate>
               </a>
             </div>
             <dl className={styles.heroStats}>
               <div>
-                <dt>Plugins</dt>
+                <dt>
+                  <Translate id="landing.hero.stat1_label" description="Stat 1 label">
+                    Plugins
+                  </Translate>
+                </dt>
                 <dd>4</dd>
               </div>
               <div>
-                <dt>Tier-0 workflows</dt>
+                <dt>
+                  <Translate id="landing.hero.stat2_label" description="Stat 2 label">
+                    Tier-0 workflows
+                  </Translate>
+                </dt>
                 <dd>9</dd>
               </div>
               <div>
-                <dt>AWS MCP servers</dt>
-                <dd>11 pinned</dd>
+                <dt>
+                  <Translate id="landing.hero.stat3_label" description="Stat 3 label">
+                    AWS MCP servers
+                  </Translate>
+                </dt>
+                <dd>
+                  <Translate id="landing.hero.stat3_value" description="Stat 3 value">
+                    11 pinned
+                  </Translate>
+                </dd>
               </div>
               <div>
-                <dt>Ontology entities</dt>
-                <dd>8 schemas</dd>
+                <dt>
+                  <Translate id="landing.hero.stat4_label" description="Stat 4 label">
+                    Ontology entities
+                  </Translate>
+                </dt>
+                <dd>
+                  <Translate id="landing.hero.stat4_value" description="Stat 4 value">
+                    8 schemas
+                  </Translate>
+                </dd>
               </div>
             </dl>
           </div>
@@ -400,8 +662,10 @@ export default function HomeLanding(): React.ReactElement {
                   &gt; /oma:autopilot <em>"ship the anomaly detector end to end"</em>
                 </p>
                 <div className={styles.mockCallout}>
-                  OMA · Inception → Construction → Operations.
-                  Approval gates: 4. Agent steps in between: ~40.
+                  <Translate id="landing.hero.mock_callout" description="Hero mock terminal callout text">
+                    OMA · Inception → Construction → Operations.
+                    Approval gates: 4. Agent steps in between: ~40.
+                  </Translate>
                 </div>
               </div>
             </div>
@@ -414,28 +678,74 @@ export default function HomeLanding(): React.ReactElement {
       {/* PROBLEM -> SOLUTION CONTRAST */}
       <section className={styles.contrast}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>The gap</p>
+          <p className={styles.kicker}>
+            <Translate id="landing.contrast.kicker" description="Contrast section kicker">
+              The gap
+            </Translate>
+          </p>
           <h2 className={styles.sectionTitle}>
-            Most AIDLC implementations stop at merge time.
+            <Translate id="landing.contrast.title" description="Contrast section title">
+              Most AIDLC implementations stop at merge time.
+            </Translate>
           </h2>
         </header>
         <div className={styles.contrastGrid}>
           <article className={`${styles.contrastCard} ${styles.contrastBefore}`}>
-            <h3>Without OMA</h3>
+            <h3>
+              <Translate id="landing.contrast.without_title" description="Without OMA heading">
+                Without OMA
+              </Translate>
+            </h3>
             <ul>
-              <li>Traces pile up in Langfuse but never become PRs.</li>
-              <li>Incident playbooks live in a wiki no on-call reads at 2am.</li>
-              <li>Cost anomalies surface on the next month's invoice.</li>
-              <li>Every operations decision is a human judgement call.</li>
+              <li>
+                <Translate id="landing.contrast.without_bullet1" description="Without OMA bullet 1">
+                  Traces pile up in Langfuse but never become PRs.
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.without_bullet2" description="Without OMA bullet 2">
+                  Incident playbooks live in a wiki no on-call reads at 2am.
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.without_bullet3" description="Without OMA bullet 3">
+                  Cost anomalies surface on the next month's invoice.
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.without_bullet4" description="Without OMA bullet 4">
+                  Every operations decision is a human judgement call.
+                </Translate>
+              </li>
             </ul>
           </article>
           <article className={`${styles.contrastCard} ${styles.contrastAfter}`}>
-            <h3>With OMA</h3>
+            <h3>
+              <Translate id="landing.contrast.with_title" description="With OMA heading">
+                With OMA
+              </Translate>
+            </h3>
             <ul>
-              <li>Trace patterns open draft PRs against the skills that caused them (once you point OMA at your Langfuse trace MCP).</li>
-              <li>SEV1 alarms get diagnosed + mitigated with a human approval gate.</li>
-              <li>Budget breaches throttle or downgrade before the ceiling hits.</li>
-              <li>Humans approve at checkpoints. Agents do the rest.</li>
+              <li>
+                <Translate id="landing.contrast.with_bullet1" description="With OMA bullet 1">
+                  Trace patterns open draft PRs against the skills that caused them (once you point OMA at your Langfuse trace MCP).
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.with_bullet2" description="With OMA bullet 2">
+                  SEV1 alarms get diagnosed + mitigated with a human approval gate.
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.with_bullet3" description="With OMA bullet 3">
+                  Budget breaches throttle or downgrade before the ceiling hits.
+                </Translate>
+              </li>
+              <li>
+                <Translate id="landing.contrast.with_bullet4" description="With OMA bullet 4">
+                  Humans approve at checkpoints. Agents do the rest.
+                </Translate>
+              </li>
             </ul>
           </article>
         </div>
@@ -444,9 +754,15 @@ export default function HomeLanding(): React.ReactElement {
       {/* SUPERPOWERS */}
       <section className={styles.superpowers}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>What changes</p>
+          <p className={styles.kicker}>
+            <Translate id="landing.superpowers.kicker" description="Superpowers section kicker">
+              What changes
+            </Translate>
+          </p>
           <h2 className={styles.sectionTitle}>
-            Three mechanisms that make AIDLC close itself.
+            <Translate id="landing.superpowers.title" description="Superpowers section title">
+              Three mechanisms that make AIDLC close itself.
+            </Translate>
           </h2>
         </header>
         <ol className={styles.superpowerList}>
@@ -465,9 +781,15 @@ export default function HomeLanding(): React.ReactElement {
       {/* INTEGRATION */}
       <section className={styles.integration}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>Drop-in</p>
+          <p className={styles.kicker}>
+            <Translate id="landing.integration.kicker" description="Integration section kicker">
+              Drop-in
+            </Translate>
+          </p>
           <h2 className={styles.sectionTitle}>
-            Ship as a plugin inside the tools you already run.
+            <Translate id="landing.integration.title" description="Integration section title">
+              Ship as a plugin inside the tools you already run.
+            </Translate>
           </h2>
         </header>
         <div className={styles.integrationGrid}>
@@ -487,47 +809,89 @@ export default function HomeLanding(): React.ReactElement {
       <section className={styles.loopSection}>
         <div className={styles.loopCard}>
           <div className={styles.loopCopy}>
-            <h2 className={styles.sectionTitleTight}>The AIDLC loop, closed.</h2>
+            <h2 className={styles.sectionTitleTight}>
+              <Translate id="landing.loop.title" description="AIDLC loop section title">
+                The AIDLC loop, closed.
+              </Translate>
+            </h2>
             <p className={styles.loopLede}>
-              Inception and Construction describe <em>what</em> will ship. Operations keeps it
-              alive after it ships — and feeds learnings back to Construction without a human
-              in the loop for routine corrections.
+              <Translate id="landing.loop.lede_before_em" description="AIDLC loop lead paragraph before emphasis">
+                Inception and Construction describe
+              </Translate>{' '}
+              <em>
+                <Translate id="landing.loop.lede_em" description="AIDLC loop lead paragraph emphasis">
+                  what
+                </Translate>
+              </em>{' '}
+              <Translate id="landing.loop.lede_after_em" description="AIDLC loop lead paragraph after emphasis">
+                will ship. Operations keeps it alive after it ships — and feeds learnings back to Construction without a human in the loop for routine corrections.
+              </Translate>
             </p>
             <ol className={styles.loopList}>
               <li>
                 <span className={styles.loopStep}>1</span>
                 <div>
-                  <h4>Inception · <code>aidlc</code></h4>
+                  <h4>
+                    <Translate id="landing.loop.step1_title" description="Loop step 1 title">
+                      Inception
+                    </Translate>{' · '}
+                    <code>aidlc</code>
+                  </h4>
                   <p>
-                    Workspace detection, adaptive requirements, user stories, workflow plan.
-                    Output artifacts become the contract Construction must honor.
+                    <Translate id="landing.loop.step1_body" description="Loop step 1 body">
+                      Workspace detection, adaptive requirements, user stories, workflow plan.
+                      Output artifacts become the contract Construction must honor.
+                    </Translate>
                   </p>
                 </div>
               </li>
               <li>
                 <span className={styles.loopStep}>2</span>
                 <div>
-                  <h4>Construction · <code>aidlc</code></h4>
+                  <h4>
+                    <Translate id="landing.loop.step2_title" description="Loop step 2 title">
+                      Construction
+                    </Translate>{' · '}
+                    <code>aidlc</code>
+                  </h4>
                   <p>
-                    Component design, code generation with human-approved gates, 12-category
-                    risk discovery, TDD for agentic systems, phase quality gates.
+                    <Translate id="landing.loop.step2_body" description="Loop step 2 body">
+                      Component design, code generation with human-approved gates, 12-category
+                      risk discovery, TDD for agentic systems, phase quality gates.
+                    </Translate>
                   </p>
                 </div>
               </li>
               <li>
                 <span className={styles.loopStep}>3</span>
                 <div>
-                  <h4>Operations · <code>agenticops</code></h4>
+                  <h4>
+                    <Translate id="landing.loop.step3_title" description="Loop step 3 title">
+                      Operations
+                    </Translate>{' · '}
+                    <code>agenticops</code>
+                  </h4>
                   <p>
-                    Autopilot deploys, continuous eval, incident response, cost governance, and
-                    the self-improving loop that feeds learnings back into Construction.
+                    <Translate id="landing.loop.step3_body" description="Loop step 3 body">
+                      Autopilot deploys, continuous eval, incident response, cost governance, and
+                      the self-improving loop that feeds learnings back into Construction.
+                    </Translate>
                   </p>
                 </div>
               </li>
             </ol>
             <p className={styles.loopFoot}>
-              Runtime (<code>ai-infra</code>) and brownfield entry (<code>modernization</code>)
-              sit alongside the loop, not inside it.
+              <Translate id="landing.loop.footer_before_ai_infra" description="AIDLC loop footer before ai-infra">
+                Runtime (
+              </Translate>
+              <code>ai-infra</code>
+              <Translate id="landing.loop.footer_between" description="AIDLC loop footer between code blocks">
+                ) and brownfield entry (
+              </Translate>
+              <code>modernization</code>
+              <Translate id="landing.loop.footer_after_modernization" description="AIDLC loop footer after modernization">
+                ) sit alongside the loop, not inside it.
+              </Translate>
             </p>
           </div>
           <div className={styles.loopVisual} aria-hidden="true">
@@ -568,8 +932,16 @@ export default function HomeLanding(): React.ReactElement {
       {/* CAPABILITIES */}
       <section className={styles.capabilities}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>AgenticOps capabilities</p>
-          <h2 className={styles.sectionTitle}>Purpose-built for the autonomous era.</h2>
+          <p className={styles.kicker}>
+            <Translate id="landing.capabilities.kicker" description="Capabilities section kicker">
+              AgenticOps capabilities
+            </Translate>
+          </p>
+          <h2 className={styles.sectionTitle}>
+            <Translate id="landing.capabilities.title" description="Capabilities section title">
+              Purpose-built for the autonomous era.
+            </Translate>
+          </h2>
         </header>
         <div className={styles.bento}>
           {CAPABILITIES.map((cap) => (
@@ -609,9 +981,15 @@ export default function HomeLanding(): React.ReactElement {
       {/* TIER-0 WORKFLOWS */}
       <section className={styles.workflows}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>Nine Tier-0 workflows</p>
+          <p className={styles.kicker}>
+            <Translate id="landing.workflows.kicker" description="Workflows section kicker">
+              Nine Tier-0 workflows
+            </Translate>
+          </p>
           <h2 className={styles.sectionTitle}>
-            Call one slash command. Get a checkpointed plan.
+            <Translate id="landing.workflows.title" description="Workflows section title">
+              Call one slash command. Get a checkpointed plan.
+            </Translate>
           </h2>
         </header>
         <div className={styles.workflowGrid}>
@@ -624,17 +1002,29 @@ export default function HomeLanding(): React.ReactElement {
           ))}
         </div>
         <p className={styles.workflowFoot}>
-          Keyword triggers auto-suggest the right command when your prompt contains a match.
-          See the <Link to={useBaseUrl('/docs/keyword-triggers')}>trigger catalog</Link>.
+          <Translate id="landing.workflows.footer" description="Workflows footer text">
+            Keyword triggers auto-suggest the right command when your prompt contains a match. See the
+          </Translate>{' '}
+          <Link to={useBaseUrl('/docs/keyword-triggers')}>
+            <Translate id="landing.workflows.trigger_catalog_link" description="Trigger catalog link text">
+              trigger catalog
+            </Translate>
+          </Link>.
         </p>
       </section>
 
       {/* PLUGINS */}
       <section className={styles.plugins}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>Four plugins</p>
+          <p className={styles.kicker}>
+            <Translate id="landing.plugins.kicker" description="Plugins section kicker">
+              Four plugins
+            </Translate>
+          </p>
           <h2 className={styles.sectionTitle}>
-            Install only what you need — or all four with one marketplace command.
+            <Translate id="landing.plugins.title" description="Plugins section title">
+              Install only what you need — or all four with one marketplace command.
+            </Translate>
           </h2>
         </header>
         <div className={styles.pluginGrid}>
@@ -654,14 +1044,26 @@ export default function HomeLanding(): React.ReactElement {
       {/* INSTALL */}
       <section className={styles.install}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>30-second install</p>
-          <h2 className={styles.sectionTitle}>Three terminal lines to a working loop.</h2>
+          <p className={styles.kicker}>
+            <Translate id="landing.install.kicker" description="Install section kicker">
+              30-second install
+            </Translate>
+          </p>
+          <h2 className={styles.sectionTitle}>
+            <Translate id="landing.install.title" description="Install section title">
+              Three terminal lines to a working loop.
+            </Translate>
+          </h2>
         </header>
         <div className={styles.installSteps}>
           <div className={styles.installStep}>
             <span className={styles.installNum}>1</span>
             <div>
-              <h4>Register the marketplace</h4>
+              <h4>
+                <Translate id="landing.install.step1_title" description="Install step 1 title">
+                  Register the marketplace
+                </Translate>
+              </h4>
               <pre><code>{`claude
 > /plugin marketplace add https://github.com/aws-samples/sample-oh-my-aidlcops`}</code></pre>
             </div>
@@ -669,7 +1071,11 @@ export default function HomeLanding(): React.ReactElement {
           <div className={styles.installStep}>
             <span className={styles.installNum}>2</span>
             <div>
-              <h4>Install the four plugins</h4>
+              <h4>
+                <Translate id="landing.install.step2_title" description="Install step 2 title">
+                  Install the four plugins
+                </Translate>
+              </h4>
               <pre><code>{`> /plugin install ai-infra@oh-my-aidlcops
 > /plugin install agenticops@oh-my-aidlcops
 > /plugin install aidlc@oh-my-aidlcops
@@ -679,11 +1085,21 @@ export default function HomeLanding(): React.ReactElement {
           <div className={styles.installStep}>
             <span className={styles.installNum}>3</span>
             <div>
-              <h4>Run a Tier-0 workflow</h4>
+              <h4>
+                <Translate id="landing.install.step3_title" description="Install step 3 title">
+                  Run a Tier-0 workflow
+                </Translate>
+              </h4>
               <pre><code>{`> /oma:autopilot "ship the anomaly detector end to end"`}</code></pre>
               <p className={styles.installHint}>
-                Or start with a safer on-ramp:{' '}
-                <Link to={useBaseUrl('/docs/getting-started')}>getting-started guide</Link>.
+                <Translate id="landing.install.hint" description="Install hint text">
+                  Or start with a safer on-ramp:
+                </Translate>{' '}
+                <Link to={useBaseUrl('/docs/getting-started')}>
+                  <Translate id="landing.install.guide_link" description="Getting started guide link text">
+                    getting-started guide
+                  </Translate>
+                </Link>.
               </p>
             </div>
           </div>
@@ -693,32 +1109,88 @@ export default function HomeLanding(): React.ReactElement {
       {/* SECURITY */}
       <section className={styles.security}>
         <div className={styles.securityInner}>
-          <p className={styles.kicker}>Secure by default</p>
-          <h2 className={styles.sectionTitleTight}>Ship-ready, not just demo-ready.</h2>
+          <p className={styles.kicker}>
+            <Translate id="landing.security.kicker" description="Security section kicker">
+              Secure by default
+            </Translate>
+          </p>
+          <h2 className={styles.sectionTitleTight}>
+            <Translate id="landing.security.title" description="Security section title">
+              Ship-ready, not just demo-ready.
+            </Translate>
+          </h2>
           <ul className={styles.securityGrid}>
             <li>
-              <h4>MCP versions pinned</h4>
-              <p>Every .mcp.json and agent profile references awslabs MCP servers by exact PyPI version. No @latest supply-chain surprises.</p>
+              <h4>
+                <Translate id="landing.security.item1_title" description="Security item 1 title">
+                  MCP versions pinned
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item1_body" description="Security item 1 body">
+                  Every .mcp.json and agent profile references awslabs MCP servers by exact PyPI version. No @latest supply-chain surprises.
+                </Translate>
+              </p>
             </li>
             <li>
-              <h4>Read-only EKS MCP</h4>
-              <p>The Kiro agent profile does not enable --allow-write or --allow-sensitive-data-access by default; opt in explicitly.</p>
+              <h4>
+                <Translate id="landing.security.item2_title" description="Security item 2 title">
+                  Read-only EKS MCP
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item2_body" description="Security item 2 body">
+                  The Kiro agent profile does not enable --allow-write or --allow-sensitive-data-access by default; opt in explicitly.
+                </Translate>
+              </p>
             </li>
             <li>
-              <h4>Least-privilege IAM</h4>
-              <p>langfuse-observability uses a bucket-scoped customer-managed policy. AmazonS3FullAccess is called out as a Bad Example.</p>
+              <h4>
+                <Translate id="landing.security.item3_title" description="Security item 3 title">
+                  Least-privilege IAM
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item3_body" description="Security item 3 body">
+                  langfuse-observability uses a bucket-scoped customer-managed policy. AmazonS3FullAccess is called out as a Bad Example.
+                </Translate>
+              </p>
             </li>
             <li>
-              <h4>Sandboxed expressions</h4>
-              <p>cost-governance evaluates budget.yaml rules with simpleeval. Python eval() on user-editable config is a documented RCE vector.</p>
+              <h4>
+                <Translate id="landing.security.item4_title" description="Security item 4 title">
+                  Sandboxed expressions
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item4_body" description="Security item 4 body">
+                  cost-governance evaluates budget.yaml rules with simpleeval. Python eval() on user-editable config is a documented RCE vector.
+                </Translate>
+              </p>
             </li>
             <li>
-              <h4>Session state stays local</h4>
-              <p>.omao/state, .omao/plans, .omao/logs, audit-trail output, and project memory are gitignored. Verbatim prompts never leave the machine.</p>
+              <h4>
+                <Translate id="landing.security.item5_title" description="Security item 5 title">
+                  Session state stays local
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item5_body" description="Security item 5 body">
+                  .omao/state, .omao/plans, .omao/logs, audit-trail output, and project memory are gitignored. Verbatim prompts never leave the machine.
+                </Translate>
+              </p>
             </li>
             <li>
-              <h4>Safe JSON hooks</h4>
-              <p>session-start.sh requires jq or python3 and refuses to emit shell-interpolated JSON, preventing state-file injection into context.</p>
+              <h4>
+                <Translate id="landing.security.item6_title" description="Security item 6 title">
+                  Safe JSON hooks
+                </Translate>
+              </h4>
+              <p>
+                <Translate id="landing.security.item6_body" description="Security item 6 body">
+                  session-start.sh requires jq or python3 and refuses to emit shell-interpolated JSON, preventing state-file injection into context.
+                </Translate>
+              </p>
             </li>
           </ul>
         </div>
@@ -727,21 +1199,37 @@ export default function HomeLanding(): React.ReactElement {
       {/* FAQ */}
       <section className={styles.faqSection}>
         <header className={styles.sectionHead}>
-          <p className={styles.kicker}>FAQ</p>
-          <h2 className={styles.sectionTitle}>Common questions before you install.</h2>
+          <p className={styles.kicker}>
+            <Translate id="landing.faq.kicker" description="FAQ section kicker">
+              FAQ
+            </Translate>
+          </p>
+          <h2 className={styles.sectionTitle}>
+            <Translate id="landing.faq.title" description="FAQ section title">
+              Common questions before you install.
+            </Translate>
+          </h2>
         </header>
         <Faq items={FAQ} />
       </section>
 
       {/* CTA */}
       <section className={styles.cta}>
-        <h2 className={styles.ctaTitle}>Stop running the operations loop by hand.</h2>
+        <h2 className={styles.ctaTitle}>
+          <Translate id="landing.cta.title" description="Final CTA title">
+            Stop running the operations loop by hand.
+          </Translate>
+        </h2>
         <p className={styles.ctaLede}>
-          Install once. Approve at the checkpoints. Let agents carry the rest of the AIDLC loop.
+          <Translate id="landing.cta.lede" description="Final CTA lead text">
+            Install once. Approve at the checkpoints. Let agents carry the rest of the AIDLC loop.
+          </Translate>
         </p>
         <div className={styles.heroCtaRow}>
           <Link className={styles.ctaPrimary} to={useBaseUrl('/docs/getting-started')}>
-            Read the getting-started guide
+            <Translate id="landing.cta.primary" description="Final CTA primary button">
+              Read the getting-started guide
+            </Translate>
           </Link>
           <a
             className={styles.ctaSecondary}
@@ -749,7 +1237,9 @@ export default function HomeLanding(): React.ReactElement {
             target="_blank"
             rel="noreferrer"
           >
-            Star on GitHub
+            <Translate id="landing.cta.secondary" description="Final CTA secondary button">
+              Star on GitHub
+            </Translate>
           </a>
         </div>
       </section>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import Layout from '@theme/Layout';
+import { translate } from '@docusaurus/Translate';
 import HomeLanding from '@site/src/components/HomeLanding';
 
 export default function Home(): React.ReactElement {
   return (
     <Layout
-      title="AIDLC × AgenticOps marketplace"
-      description="Extend Claude Code and Kiro with AgenticOps plugins and skills that automate the AWS AI-Driven Development Lifecycle: Inception, Construction, Operations."
+      title={translate({
+        id: 'page.home.title',
+        message: 'AIDLC × AgenticOps marketplace',
+        description: 'Home page title',
+      })}
+      description={translate({
+        id: 'page.home.description',
+        message:
+          'Extend Claude Code and Kiro with AgenticOps plugins and skills that automate the AWS AI-Driven Development Lifecycle: Inception, Construction, Operations.',
+        description: 'Home page description',
+      })}
     >
       <HomeLanding />
     </Layout>


### PR DESCRIPTION
Fixes #29.

## Problem
The home landing page rendered entirely in English even though `docusaurus.config.ts` sets `defaultLocale: 'ko'`. Root cause: `docs/src/components/HomeLanding/index.tsx` and `docs/src/pages/index.tsx` were 100% hardcoded English with **zero** `<Translate>` / `translate()` usage, and `docs/i18n/ko/` did not exist — so locale selection could not affect the component layer. (The markdown docs were already Korean-first; only the component layer was stuck in English.)

## Fix (Option A — full landing i18n)
1. **Component refactor** — wrap every user-facing string in the Docusaurus v3 i18n API: JSX text via `<Translate id=…>`, data-array/prop strings via `translate({id,message})`. Stable `landing.*` / `page.home.*` ids (131 strings). Left verbatim: plugin names, slash commands, keyword/skill identifiers, CLI & mock-terminal blocks, stats, SVG. English render is structurally unchanged.
2. **Korean translations** — authored `i18n/ko/code.json` (215 entries incl. theme) + `navbar.json` / `footer.json` / docs `current.json`, matching the existing Korean voice (README.ko.md / intro / philosophy: 이지버튼, 신뢰성 2축, 온톨로지/하네스 엔지니어링, Outer Loop). Proper nouns kept verbatim.

## Verification
- `npm run build` clean for **both** locales (`build/` ko + `build/en/`): 0 link warnings, 0 broken links.
- Built ko `index.html` confirmed rendering Korean (hero: "AIDLC 운영 공백은 여전히…").
- `/en/` still renders the original English unchanged.

## Notes
- `i18n/ko/` is committed (it was absent before → builds were non-reproducible for the ko locale).
- `releases.tsx` static labels are out of scope here (separate, minor); can follow up if desired.