### PR TITLE
fix(ci): add numpy/promql-parser to dev extras to unblock foundation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4,<9",
+    "numpy>=1.26,<3",
+    "promql-parser>=0.4,<1",
 ]
 
 [project.urls]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Summary
- `tests/test_aiops_skills.py` and `tests/test_promql_validation.py` (added in #30) import `numpy` and `promql_parser` at module top-level, but neither package was declared anywhere in `pyproject.toml`.
- The `foundation` workflow installs only `pip install -e '.[dev]'`, so on `main` pytest collection failed with `ModuleNotFoundError` for both modules — exit 2 before any test ran.
- This adds both packages to `[project.optional-dependencies].dev`, scoped intentionally so end-user installs (`pip install oh-my-aidlcops` / `bash scripts/install/{claude,kiro}.sh`) are unaffected.

## Why dev extras only (not base `dependencies`)
- Runtime grep across `tools/`, `scripts/`, `bin/` shows zero usage of `numpy` or `promql_parser` — both are imported only by the two test modules.
- `plugins/agenticops/skills/` ships as Markdown only (no `.py`), so the skills themselves never need these libs.
- Adding them to base `dependencies` would push ~30 MB of numpy onto every consumer with no runtime payoff.

## Repro (on `main`, before this fix)
```bash
python3.11 -m venv /tmp/v
/tmp/v/bin/pip install -e '.[dev]'
/tmp/v/bin/python -m pytest tests/ \
  --ignore=tests/installer --ignore=tests/profile \
  --ignore=tests/hooks --ignore=tests/doctor
# → ERROR collecting tests/test_aiops_skills.py     (No module named 'numpy')
# → ERROR collecting tests/test_promql_validation.py (No module named 'promql_parser')
# → Interrupted: 2 errors during collection — exit 2
```

