### PR TITLE
docs(site): add Knowledge Wiki page, clarify AIDLC loop value, fix stale OPA ref

### DIFF
--- a/docs/docs/knowledge-wiki.md
+++ b/docs/docs/knowledge-wiki.md
@@ -1,0 +1,124 @@
+---
+id: knowledge-wiki
+title: Knowledge Wiki
+sidebar_position: 6
+---
+
+# Knowledge Wiki — the retrieval layer that grounds the ontology
+
+:::info Status — design proposal, not yet shipped
+OMA does **not** ship a knowledge-wiki component today. This page describes a
+proposed layer and the reasoning behind it, so the design is reviewable before
+any code lands. The [Ontology](./ontology.md) (8 JSON Schemas) and
+[Harness](./harness-dsl.md) (PreToolUse enforcement) layers described elsewhere
+**are** implemented. Treat everything below as roadmap unless a later release
+note says otherwise.
+:::
+
+## The gap: the ontology validates *after* generation
+
+The [Ontology Engineering](./ontology-engineering.md) axis guarantees
+correctness with a **post-hoc** mechanism:
+
+```
+agent writes entity YAML  ──▶  oma validate  ──▶  schema violation → rejected
+```
+
+This catches a malformed `Deployment` or an undeclared `Risk` classification.
+What it cannot do is tell an agent, *before* it writes anything, what the domain
+already knows:
+
+- Is `Deployment.target` already an enum (`eks | ec2 | lambda`), or am I free to
+  invent a cluster-name string?
+- Has a `Risk` like this one been classified under OWASP or NIST before, and how?
+- Why was the `Payment` aggregate split into `CustomerReference` +
+  `CustomerProfile` — was that an `ADR`, and what triggered it?
+
+The ontology's origin story on the [Ontology](./ontology.md) page is exactly
+this failure: `autopilot-deploy` and `construction-loop` both said "deployment
+target" and meant different things. Validation only caught the clash *after* the
+conflicting documents existed. The handoff still cost a human re-read.
+
+## The proposal: a semantic retrieval layer queried *before* generation
+
+A knowledge wiki is a corpus of natural-language reference pages — entity
+definitions, the narrative behind each `ADR`, worked examples, naming
+conventions — indexed for **semantic search**. An agent queries it *before*
+producing a typed artifact, so it generates grounded in what already exists
+instead of re-deriving (and drifting from) it.
+
+The three layers are complementary, not competing — each acts at a different
+moment:
+
+| Layer | What it holds | Form | When it acts | Status |
+|---|---|---|---|---|
+| **Knowledge wiki** | definitions, decision narratives, precedent, conventions | unstructured, semantically searchable | *before* generation (retrieval / grounding) | 🔭 proposed |
+| **Ontology** (8 schemas) | the typed world model — entities, fields, invariants | structured, machine-validated | *after* generation (validation) | ✅ shipped |
+| **Harness** (PreToolUse) | execution deny rules | compiled regex rules | *before* a tool runs (enforcement) | ✅ shipped |
+
+The ontology answers **"is this true?"** The wiki answers **"what is already
+known?"** A type system rejects a wrong answer; it does not supply the right
+one. The wiki supplies the context that makes the first answer correct.
+
+## How the wiki makes the ontology *more accurate*
+
+Three concrete paths, each tied to a failure the ontology page already names:
+
+1. **Pre-generation grounding (prevents drift instead of catching it).**
+   The agent retrieves existing definitions, enums, and synonyms before writing.
+   A duplicate or renamed concept is avoided at the source, rather than surfaced
+   as a validation clash after two skills have already diverged. This attacks the
+   "deployment target" failure at generation time, not handoff time.
+
+2. **Decision narratives that structured links cannot hold.**
+   The 8 schemas connect by `id` reference (`Deployment.adr_refs: ["ADR-014"]`) —
+   structural, but silent on *why*. The wiki preserves the prose behind a
+   decision (the `Payment` → `CustomerReference` + `CustomerProfile` redesign and
+   the P99 signal that triggered it) so the
+   [Outer Loop](./ontology-engineering.md#agenticops-as-the-outer-loop) can reuse
+   past reasoning instead of re-litigating it.
+
+3. **A second input to schema evolution.**
+   Today the Outer Loop's `self-improving-loop` consumes operational signal
+   (traces, metrics, incidents). A wiki adds *accumulated domain knowledge* as a
+   second input, so a proposed schema change is grounded in both what operations
+   observed and what the domain has already established.
+
+## How this connects to evolving the ontology
+
+[Ontology](./ontology.md#evolving-the-ontology) already defines the evolution
+rules: add fields before inventing entities; new enum values need a documented
+rationale; breaking changes bump the DSL `version:`. Those rules say *what is
+allowed*. A wiki would feed *what is informed* into each step of the
+[triple feedback loop](./ontology-engineering.md#the-triple-feedback-loop--a-living-ontology):
+
+| Loop | Cadence | Without a wiki | With a wiki (proposed) |
+|---|---|---|---|
+| **Inner** | minutes | add a constraint from a single test failure | check whether the constraint already exists or contradicts a documented convention before adding it |
+| **Middle** | days | bump a schema from a repeated PR pattern | retrieve prior decisions on the same entity so the schema change is consistent with established intent |
+| **Outer** | weeks | redesign the domain model from operational signal alone | combine operational signal with the recorded narrative of *why the model is shaped as it is* |
+
+In each case the wiki does not change *what the ontology enforces* — the schemas
+remain the single source of truth, validated by `oma validate`. It changes how
+*accurately* the next ontology edit is proposed, by making prior knowledge
+retrievable at the moment of authorship.
+
+## Open design questions
+
+These must be resolved in an [ADR](./ontology.md) before implementation:
+
+- **Source of truth.** The wiki must derive from the schemas + `ADR`/`Spec`
+  documents, never the reverse, or it becomes a competing definition of the
+  domain and reintroduces the drift it is meant to prevent.
+- **Staleness.** A retrieval layer that lags the schemas is worse than none.
+  Ingestion would need to re-run on every ontology change (an Inner-Loop hook).
+- **Retrieval surface.** Whether agents query the wiki via an MCP tool, a skill,
+  or a build-time index is an interface decision with different harness
+  implications for each.
+
+## References
+
+- [Ontology Engineering](./ontology-engineering.md) — the correctness axis this layer serves
+- [Ontology](./ontology.md) — the 8-entity schema reference and evolution rules
+- [Harness Engineering](./harness-engineering.md) — the safety axis, for contrast on *when* each layer acts
+- [engineering-playbook — Ontology Engineering](https://devfloor9.github.io/engineering-playbook/docs/aidlc/methodology/ontology-engineering) — the living-ontology source ([REFERENCES](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/REFERENCES.md#ep-ontology-engineering))

--- a/docs/docs/ontology-engineering.md
+++ b/docs/docs/ontology-engineering.md
@@ -51,9 +51,15 @@ OMA realizes this as **8 JSON-Schema entities** (Draft 2020-12) in
 | `Deployment` | The validated Construction→Operations handoff document |
 | `Incident`, `Budget`, `Risk` | Operations-side facts that feed the Outer Loop |
 
-`oma validate <entity.yaml>` enforces schema + OPA policy on all 8 — the mechanical
+`oma validate <entity.yaml>` enforces the JSON Schema on all 8 — the mechanical
 "violation detection" the methodology calls for. See [Ontology](./ontology.md) for
 field-level detail.
+
+This validation is **post-hoc**: it catches a wrong artifact after it is
+written. The proposed [Knowledge Wiki](./knowledge-wiki.md) is the complementary
+*pre-generation* retrieval layer — it grounds an agent in what the domain
+already defines *before* it produces an entity, so drift is prevented at the
+source rather than caught at the handoff.
 
 ## The triple feedback loop — a living ontology
 

--- a/docs/docs/ontology.md
+++ b/docs/docs/ontology.md
@@ -104,4 +104,11 @@ user-editable input.
 3. Breaking changes (required-field additions, enum narrowing) require a DSL
    `version:` bump in `schemas/harness/dsl.schema.json`.
 
+These rules define *what is allowed* to change. They do not help an author know
+*what already exists* before proposing a change — which is where duplication and
+drift creep in. The proposed [Knowledge Wiki](./knowledge-wiki.md) is the
+retrieval layer that closes that gap: it makes prior definitions, decisions, and
+conventions searchable at the moment of authorship, so each schema edit is
+grounded in established intent rather than re-derived.
+
 Full glossary: [ontology/glossary.md](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/ontology/glossary.md).

--- a/docs/i18n/ko/code.json
+++ b/docs/i18n/ko/code.json
@@ -340,7 +340,7 @@
     "description": "Integration section title"
   },
   "landing.loop.title": {
-    "message": "닫힌 AIDLC 루프.",
+    "message": "멈추지 않고 출시되는 루프.",
     "description": "AIDLC loop section title"
   },
   "landing.loop.lede_before_em": {

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/knowledge-wiki.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/knowledge-wiki.md
@@ -1,0 +1,124 @@
+---
+id: knowledge-wiki
+title: Knowledge Wiki
+sidebar_position: 6
+---
+
+# Knowledge Wiki — the retrieval layer that grounds the ontology
+
+:::info Status — design proposal, not yet shipped
+OMA does **not** ship a knowledge-wiki component today. This page describes a
+proposed layer and the reasoning behind it, so the design is reviewable before
+any code lands. The [Ontology](./ontology.md) (8 JSON Schemas) and
+[Harness](./harness-dsl.md) (PreToolUse enforcement) layers described elsewhere
+**are** implemented. Treat everything below as roadmap unless a later release
+note says otherwise.
+:::
+
+## The gap: the ontology validates *after* generation
+
+The [Ontology Engineering](./ontology-engineering.md) axis guarantees
+correctness with a **post-hoc** mechanism:
+
+```
+agent writes entity YAML  ──▶  oma validate  ──▶  schema violation → rejected
+```
+
+This catches a malformed `Deployment` or an undeclared `Risk` classification.
+What it cannot do is tell an agent, *before* it writes anything, what the domain
+already knows:
+
+- Is `Deployment.target` already an enum (`eks | ec2 | lambda`), or am I free to
+  invent a cluster-name string?
+- Has a `Risk` like this one been classified under OWASP or NIST before, and how?
+- Why was the `Payment` aggregate split into `CustomerReference` +
+  `CustomerProfile` — was that an `ADR`, and what triggered it?
+
+The ontology's origin story on the [Ontology](./ontology.md) page is exactly
+this failure: `autopilot-deploy` and `construction-loop` both said "deployment
+target" and meant different things. Validation only caught the clash *after* the
+conflicting documents existed. The handoff still cost a human re-read.
+
+## The proposal: a semantic retrieval layer queried *before* generation
+
+A knowledge wiki is a corpus of natural-language reference pages — entity
+definitions, the narrative behind each `ADR`, worked examples, naming
+conventions — indexed for **semantic search**. An agent queries it *before*
+producing a typed artifact, so it generates grounded in what already exists
+instead of re-deriving (and drifting from) it.
+
+The three layers are complementary, not competing — each acts at a different
+moment:
+
+| Layer | What it holds | Form | When it acts | Status |
+|---|---|---|---|---|
+| **Knowledge wiki** | definitions, decision narratives, precedent, conventions | unstructured, semantically searchable | *before* generation (retrieval / grounding) | 🔭 proposed |
+| **Ontology** (8 schemas) | the typed world model — entities, fields, invariants | structured, machine-validated | *after* generation (validation) | ✅ shipped |
+| **Harness** (PreToolUse) | execution deny rules | compiled regex rules | *before* a tool runs (enforcement) | ✅ shipped |
+
+The ontology answers **"is this true?"** The wiki answers **"what is already
+known?"** A type system rejects a wrong answer; it does not supply the right
+one. The wiki supplies the context that makes the first answer correct.
+
+## How the wiki makes the ontology *more accurate*
+
+Three concrete paths, each tied to a failure the ontology page already names:
+
+1. **Pre-generation grounding (prevents drift instead of catching it).**
+   The agent retrieves existing definitions, enums, and synonyms before writing.
+   A duplicate or renamed concept is avoided at the source, rather than surfaced
+   as a validation clash after two skills have already diverged. This attacks the
+   "deployment target" failure at generation time, not handoff time.
+
+2. **Decision narratives that structured links cannot hold.**
+   The 8 schemas connect by `id` reference (`Deployment.adr_refs: ["ADR-014"]`) —
+   structural, but silent on *why*. The wiki preserves the prose behind a
+   decision (the `Payment` → `CustomerReference` + `CustomerProfile` redesign and
+   the P99 signal that triggered it) so the
+   [Outer Loop](./ontology-engineering.md#agenticops-as-the-outer-loop) can reuse
+   past reasoning instead of re-litigating it.
+
+3. **A second input to schema evolution.**
+   Today the Outer Loop's `self-improving-loop` consumes operational signal
+   (traces, metrics, incidents). A wiki adds *accumulated domain knowledge* as a
+   second input, so a proposed schema change is grounded in both what operations
+   observed and what the domain has already established.
+
+## How this connects to evolving the ontology
+
+[Ontology](./ontology.md#evolving-the-ontology) already defines the evolution
+rules: add fields before inventing entities; new enum values need a documented
+rationale; breaking changes bump the DSL `version:`. Those rules say *what is
+allowed*. A wiki would feed *what is informed* into each step of the
+[triple feedback loop](./ontology-engineering.md#the-triple-feedback-loop--a-living-ontology):
+
+| Loop | Cadence | Without a wiki | With a wiki (proposed) |
+|---|---|---|---|
+| **Inner** | minutes | add a constraint from a single test failure | check whether the constraint already exists or contradicts a documented convention before adding it |
+| **Middle** | days | bump a schema from a repeated PR pattern | retrieve prior decisions on the same entity so the schema change is consistent with established intent |
+| **Outer** | weeks | redesign the domain model from operational signal alone | combine operational signal with the recorded narrative of *why the model is shaped as it is* |
+
+In each case the wiki does not change *what the ontology enforces* — the schemas
+remain the single source of truth, validated by `oma validate`. It changes how
+*accurately* the next ontology edit is proposed, by making prior knowledge
+retrievable at the moment of authorship.
+
+## Open design questions
+
+These must be resolved in an [ADR](./ontology.md) before implementation:
+
+- **Source of truth.** The wiki must derive from the schemas + `ADR`/`Spec`
+  documents, never the reverse, or it becomes a competing definition of the
+  domain and reintroduces the drift it is meant to prevent.
+- **Staleness.** A retrieval layer that lags the schemas is worse than none.
+  Ingestion would need to re-run on every ontology change (an Inner-Loop hook).
+- **Retrieval surface.** Whether agents query the wiki via an MCP tool, a skill,
+  or a build-time index is an interface decision with different harness
+  implications for each.
+
+## References
+
+- [Ontology Engineering](./ontology-engineering.md) — the correctness axis this layer serves
+- [Ontology](./ontology.md) — the 8-entity schema reference and evolution rules
+- [Harness Engineering](./harness-engineering.md) — the safety axis, for contrast on *when* each layer acts
+- [engineering-playbook — Ontology Engineering](https://devfloor9.github.io/engineering-playbook/docs/aidlc/methodology/ontology-engineering) — the living-ontology source ([REFERENCES](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/REFERENCES.md#ep-ontology-engineering))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'ontology-engineering',
         'harness-engineering',
+        'knowledge-wiki',
       ],
     },
     {

--- a/docs/src/components/HomeLanding/index.tsx
+++ b/docs/src/components/HomeLanding/index.tsx
@@ -811,7 +811,7 @@ export default function HomeLanding(): React.ReactElement {
           <div className={styles.loopCopy}>
             <h2 className={styles.sectionTitleTight}>
               <Translate id="landing.loop.title" description="AIDLC loop section title">
-                The AIDLC loop, closed.
+                The loop that keeps shipping.
               </Translate>
             </h2>
             <p className={styles.loopLede}>


### PR DESCRIPTION
## Summary

Three documentation/site improvements, all in `docs/`:

### 1. New page: Knowledge Wiki (`docs/docs/knowledge-wiki.md`)
Proposes a **pre-generation semantic retrieval layer** that grounds the ontology. It is honestly framed as a **design proposal (not yet shipped)** and positioned against the two layers that *are* shipped:

| Layer | When it acts | Status |
|---|---|---|
| **Knowledge wiki** | *before* generation (retrieval / grounding) | proposed |
| **Ontology** (8 schemas) | *after* generation (validation) | shipped |
| **Harness** (PreToolUse) | *before* a tool runs (enforcement) | shipped |

The page explains how a wiki improves ontology *accuracy* (prevents drift at the source instead of catching it at the handoff), how it feeds the triple feedback loop, and the open design questions (source of truth, staleness, retrieval surface) that an ADR must resolve first.

- Registered under the **Reliability dual-axis** sidebar category; the navbar picks it up automatically via the `docSidebar`.
- i18n/ko copy added (matches the site's English-copy convention for the ko locale).
- Cross-linked from `ontology-engineering.md` and `ontology.md` ("Evolving the ontology").

### 2. Fix stale OPA reference (`ontology-engineering.md`)
`oma validate` was described as enforcing "schema + OPA policy". After the pure-CC harness migration (#50) `oma validate` is **JSON-Schema-only**. Corrected to "the JSON Schema".

### 3. Landing copy (`HomeLanding`)
`"The AIDLC loop, closed."` → `"The loop that keeps shipping."` The old phrasing was ambiguous (closed = finished? closed-loop?) and did not convey the value. The new line states the living-loop value directly: the loop never finishes — operations keeps feeding the next build. ko translation updated in `i18n/ko/code.json`.

## Verification
- `npm run build` → **exit 0**, EN + KO both `[SUCCESS]`.
- The new page's links (incl. anchor links) resolve in both locales.
- The only remaining broken-link warning is the pre-existing `architecture` page on `main`, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)