### PR TITLE
refactor(ontology): extract shared enums and wire approval-chain via $ref

### DIFF
--- a/schemas/audit/event.schema.json
+++ b/schemas/audit/event.schema.json
@@ -53,7 +53,7 @@
       "required": ["entity_type", "entity_id"],
       "properties": {
         "entity_type": {
-          "enum": ["Agent", "Skill", "Deployment", "Incident", "Budget", "Risk", "Spec", "ADR"]
+          "$ref": "../common/enums.schema.json#/$defs/entityRef"
         },
         "entity_id": {
           "type": "string",
@@ -63,7 +63,7 @@
       }
     },
     "phase": {
-      "enum": ["inception", "construction", "operations"]
+      "$ref": "../common/enums.schema.json#/$defs/aidlcPhase"
     },
     "compliance": {
       "type": "object",

--- a/schemas/common/enums.schema.json
+++ b/schemas/common/enums.schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://aws-samples.github.io/sample-oh-my-aidlcops/schemas/common/enums.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OMA Shared Enums",
+  "description": "Single source of truth for enumerations reused across ontology, harness, and audit schemas. All consumers $ref into this file to prevent drift.",
+  "$defs": {
+    "entityRef": {
+      "description": "Reference to an OMA ontology entity type.",
+      "enum": ["Agent", "Skill", "Deployment", "Incident", "Budget", "Risk", "Spec", "ADR"]
+    },
+    "blastRadius": {
+      "description": "How far damage spreads if a Deployment misbehaves or an Incident escalates. Values map to AWS constructs.",
+      "enum": ["single-namespace", "single-cluster", "single-account", "cross-account", "cross-region"]
+    },
+    "approvalState": {
+      "description": "Shared approval lifecycle used by Deployment. Agents write 'proposed'; humans write 'approved' or 'rejected'; the harness writes terminal states.",
+      "enum": ["draft", "proposed", "approved", "rejected", "deployed", "rolled_back"]
+    },
+    "incidentApprovalState": {
+      "description": "Approval lifecycle for Incident. Mirrors Deployment but with incident-specific terminal states.",
+      "enum": ["draft", "proposed", "approved", "rejected", "mitigated", "closed"]
+    },
+    "aidlcPhase": {
+      "description": "AIDLC lifecycle phase.",
+      "enum": ["inception", "construction", "operations"]
+    }
+  }
+}

--- a/schemas/harness/dsl.schema.json
+++ b/schemas/harness/dsl.schema.json
@@ -117,12 +117,12 @@
           "properties": {
             "produces": {
               "type": "array",
-              "items": { "$ref": "../ontology/agent.schema.json#/definitions/entityRef" },
+              "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
               "uniqueItems": true
             },
             "consumes": {
               "type": "array",
-              "items": { "$ref": "../ontology/agent.schema.json#/definitions/entityRef" },
+              "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
               "uniqueItems": true
             }
           }
@@ -296,7 +296,7 @@
         },
         "phase": {
           "type": "array",
-          "items": { "enum": ["inception", "construction", "operations"] },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/aidlcPhase" },
           "minItems": 1,
           "uniqueItems": true
         },

--- a/schemas/ontology/agent.schema.json
+++ b/schemas/ontology/agent.schema.json
@@ -40,12 +40,12 @@
       "properties": {
         "produces": {
           "type": "array",
-          "items": { "$ref": "#/definitions/entityRef" },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         },
         "consumes": {
           "type": "array",
-          "items": { "$ref": "#/definitions/entityRef" },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         }
       }
@@ -67,8 +67,8 @@
   },
   "definitions": {
     "entityRef": {
-      "description": "Reference to another ontology entity type.",
-      "enum": ["Agent", "Skill", "Deployment", "Incident", "Budget", "Risk", "Spec", "ADR"]
+      "description": "Deprecated local alias — prefer $ref to common/enums.schema.json#/$defs/entityRef. Kept for backward compatibility with external consumers that $ref agent.schema.json#/definitions/entityRef.",
+      "$ref": "../common/enums.schema.json#/$defs/entityRef"
     }
   }
 }

--- a/schemas/ontology/deployment.schema.json
+++ b/schemas/ontology/deployment.schema.json
@@ -73,7 +73,7 @@
     },
     "approval_state": {
       "description": "Human-in-the-loop checkpoint state. AgenticOps only progresses on 'approved'.",
-      "enum": ["draft", "proposed", "approved", "rejected", "deployed", "rolled_back"]
+      "$ref": "../common/enums.schema.json#/$defs/approvalState"
     },
     "rollback_plan": {
       "description": "Path or inline description of how to roll back. Required before approval_state=approved in strict mode.",
@@ -81,7 +81,7 @@
     },
     "blast_radius": {
       "description": "What breaks if this deployment misbehaves. Used by incident-response skill.",
-      "enum": ["single-namespace", "single-cluster", "single-account", "cross-account", "cross-region"]
+      "$ref": "../common/enums.schema.json#/$defs/blastRadius"
     },
     "produced_by": {
       "description": "Agent or skill id that generated this deployment.",
@@ -97,20 +97,8 @@
       "items": { "type": "string" }
     },
     "approval_chain": {
-      "description": "Optional ordered list of approvals gating approval_state=approved. Shape defined in schemas/common/approval-chain.schema.json#/$defs/approvalChain. Under --strict-enterprise this array must be non-empty when approval_state=approved.",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["approver", "approved_at", "reason"],
-        "properties": {
-          "approver": { "type": "string", "minLength": 1, "maxLength": 128 },
-          "approved_at": { "type": "string", "format": "date-time" },
-          "reason": { "type": "string", "minLength": 1, "maxLength": 1000 },
-          "role": { "type": "string", "maxLength": 64 }
-        }
-      }
+      "description": "Optional ordered list of approvals gating approval_state=approved. Under --strict-enterprise this array must be non-empty when approval_state=approved.",
+      "$ref": "../common/approval-chain.schema.json#/$defs/approvalChain"
     },
     "risk_exceptions": {
       "description": "Risk.id values whose gate_ref was explicitly waived for this deployment. Closes the Risk -> Deployment traceability gap.",

--- a/schemas/ontology/incident.schema.json
+++ b/schemas/ontology/incident.schema.json
@@ -26,14 +26,14 @@
       "type": "string"
     },
     "blast_radius": {
-      "enum": ["single-namespace", "single-cluster", "single-account", "cross-account", "cross-region"]
+      "$ref": "../common/enums.schema.json#/$defs/blastRadius"
     },
     "proposed_fix": {
       "description": "Free-form description of the fix the agent wants to apply. Must be human-reviewable before execution.",
       "type": "string"
     },
     "approval_state": {
-      "enum": ["draft", "proposed", "approved", "rejected", "mitigated", "closed"]
+      "$ref": "../common/enums.schema.json#/$defs/incidentApprovalState"
     },
     "runbook_ref": {
       "description": "Path or URL to the runbook the agent consulted.",
@@ -45,20 +45,8 @@
       "items": { "type": "string" }
     },
     "approval_chain": {
-      "description": "Optional approvals for runbook overrides. Matches schemas/common/approval-chain.schema.json#/$defs/approvalChain.",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["approver", "approved_at", "reason"],
-        "properties": {
-          "approver": { "type": "string", "minLength": 1, "maxLength": 128 },
-          "approved_at": { "type": "string", "format": "date-time" },
-          "reason": { "type": "string", "minLength": 1, "maxLength": 1000 },
-          "role": { "type": "string", "maxLength": 64 }
-        }
-      }
+      "description": "Optional approvals for runbook overrides.",
+      "$ref": "../common/approval-chain.schema.json#/$defs/approvalChain"
     },
     "trace_id": {
       "description": "Optional OpenTelemetry trace id (hex, 32 chars) linking the incident to distributed traces.",

--- a/schemas/ontology/skill.schema.json
+++ b/schemas/ontology/skill.schema.json
@@ -36,18 +36,18 @@
       "properties": {
         "produces": {
           "type": "array",
-          "items": { "$ref": "agent.schema.json#/definitions/entityRef" },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         },
         "consumes": {
           "type": "array",
-          "items": { "$ref": "agent.schema.json#/definitions/entityRef" },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         },
         "references": {
           "description": "Entities this skill reads but does not produce (e.g., cost-governance references Budget).",
           "type": "array",
-          "items": { "$ref": "agent.schema.json#/definitions/entityRef" },
+          "items": { "$ref": "../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         }
       }

--- a/schemas/skill-frontmatter.schema.json
+++ b/schemas/skill-frontmatter.schema.json
@@ -63,17 +63,17 @@
       "properties": {
         "produces": {
           "type": "array",
-          "items": { "$ref": "#/definitions/entityRef" },
+          "items": { "$ref": "ontology/../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         },
         "consumes": {
           "type": "array",
-          "items": { "$ref": "#/definitions/entityRef" },
+          "items": { "$ref": "ontology/../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         },
         "references": {
           "type": "array",
-          "items": { "$ref": "#/definitions/entityRef" },
+          "items": { "$ref": "ontology/../common/enums.schema.json#/$defs/entityRef" },
           "uniqueItems": true
         }
       }
@@ -85,7 +85,8 @@
   ],
   "definitions": {
     "entityRef": {
-      "enum": ["Agent", "Skill", "Deployment", "Incident", "Budget", "Risk", "Spec", "ADR"]
+      "description": "Deprecated local alias — prefer $ref to common/enums.schema.json#/$defs/entityRef.",
+      "$ref": "common/enums.schema.json#/$defs/entityRef"
     }
   },
   "title": "SKILL.md Frontmatter",

--- a/tests/audit/test_event_schema.py
+++ b/tests/audit/test_event_schema.py
@@ -8,17 +8,39 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator, FormatChecker
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMON_DIR = REPO_ROOT / "schemas" / "common"
+
 SCHEMA = json.loads(
-    (Path(__file__).resolve().parents[2] / "schemas" / "audit" / "event.schema.json").read_text(
+    (REPO_ROOT / "schemas" / "audit" / "event.schema.json").read_text(
         encoding="utf-8"
     )
 )
 
 
+def _build_registry():
+    """Build a referencing.Registry so Draft202012Validator resolves $ref to common schemas."""
+    try:
+        import referencing
+        from referencing import jsonschema as ref_jsonschema
+    except ImportError:
+        return None
+
+    resources = []
+    for common in COMMON_DIR.glob("*.schema.json"):
+        content = json.loads(common.read_text(encoding="utf-8"))
+        resource = ref_jsonschema.DRAFT202012.create_resource(content)
+        resources.append((content["$id"], resource))
+        resources.append((f"../common/{common.name}", resource))
+    return referencing.Registry().with_resources(resources)
+
+
 def _validator() -> Draft202012Validator:
-    # Explicit format-checker so ``format: date-time`` is enforced. Without it,
-    # Draft202012Validator treats ``format`` as annotation-only.
-    return Draft202012Validator(SCHEMA, format_checker=FormatChecker())
+    registry = _build_registry()
+    kwargs = {"format_checker": FormatChecker()}
+    if registry is not None:
+        kwargs["registry"] = registry
+    return Draft202012Validator(SCHEMA, **kwargs)
 
 
 APPROVE_OK = {

--- a/tests/audit/test_writer_migration.py
+++ b/tests/audit/test_writer_migration.py
@@ -11,13 +11,27 @@ import pytest
 from jsonschema import Draft202012Validator, FormatChecker
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMON_DIR = REPO_ROOT / "schemas" / "common"
 SCHEMA = json.loads(
     (REPO_ROOT / "schemas" / "audit" / "event.schema.json").read_text(encoding="utf-8")
 )
 
 
 def _validator() -> Draft202012Validator:
-    return Draft202012Validator(SCHEMA, format_checker=FormatChecker())
+    try:
+        import referencing
+        from referencing import jsonschema as ref_jsonschema
+
+        resources = []
+        for common in COMMON_DIR.glob("*.schema.json"):
+            content = json.loads(common.read_text(encoding="utf-8"))
+            resource = ref_jsonschema.DRAFT202012.create_resource(content)
+            resources.append((content["$id"], resource))
+            resources.append((f"../common/{common.name}", resource))
+        registry = referencing.Registry().with_resources(resources)
+        return Draft202012Validator(SCHEMA, format_checker=FormatChecker(), registry=registry)
+    except ImportError:
+        return Draft202012Validator(SCHEMA, format_checker=FormatChecker())
 
 
 def test_component_design_migration_command(tmp_path):

--- a/tests/harness/test_dsl_schema.py
+++ b/tests/harness/test_dsl_schema.py
@@ -11,6 +11,7 @@ from jsonschema import Draft7Validator, RefResolver
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DSL_SCHEMA = REPO_ROOT / "schemas" / "harness" / "dsl.schema.json"
 ONTOLOGY_DIR = REPO_ROOT / "schemas" / "ontology"
+COMMON_DIR = REPO_ROOT / "schemas" / "common"
 
 
 def _validator() -> Draft7Validator:
@@ -20,6 +21,10 @@ def _validator() -> Draft7Validator:
         content = json.loads(other.read_text(encoding="utf-8"))
         store[content["$id"]] = content
         store["../ontology/" + other.name] = content
+    for common in COMMON_DIR.glob("*.schema.json"):
+        content = json.loads(common.read_text(encoding="utf-8"))
+        store[content["$id"]] = content
+        store["../common/" + common.name] = content
     resolver = RefResolver.from_schema(schema, store=store)
     return Draft7Validator(schema, resolver=resolver)
 

--- a/tests/ontology/test_schemas.py
+++ b/tests/ontology/test_schemas.py
@@ -13,6 +13,7 @@ import pytest
 from jsonschema import Draft7Validator, RefResolver
 
 SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schemas" / "ontology"
+COMMON_DIR = Path(__file__).resolve().parents[2] / "schemas" / "common"
 
 
 def _load(name: str) -> dict:
@@ -22,12 +23,19 @@ def _load(name: str) -> dict:
 
 def _validator(schema_name: str) -> Draft7Validator:
     schema = _load(schema_name)
-    # Resolve cross-schema $ref (skill -> agent) by mapping $id -> local content.
+    # Resolve cross-schema $ref by mapping $id -> local content.
     store = {}
     for other in SCHEMA_DIR.glob("*.schema.json"):
         content = json.loads(other.read_text(encoding="utf-8"))
         store[content["$id"]] = content
         store[other.name] = content  # allow relative "agent.schema.json" refs
+    # Include common schemas so ../common/enums.schema.json refs resolve.
+    for common in COMMON_DIR.glob("*.schema.json"):
+        content = json.loads(common.read_text(encoding="utf-8"))
+        store[content["$id"]] = content
+        store[common.name] = content
+        # Allow relative path resolution from ontology dir.
+        store[f"../common/{common.name}"] = content
     resolver = RefResolver.from_schema(schema, store=store)
     return Draft7Validator(schema, resolver=resolver)
 

--- a/tests/ontology/test_slsa_artifact.py
+++ b/tests/ontology/test_slsa_artifact.py
@@ -9,6 +9,7 @@ import pytest
 from jsonschema import Draft7Validator, RefResolver
 
 SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schemas" / "ontology"
+COMMON_DIR = Path(__file__).resolve().parents[2] / "schemas" / "common"
 
 
 def _validator() -> Draft7Validator:
@@ -18,6 +19,11 @@ def _validator() -> Draft7Validator:
         content = json.loads(other.read_text(encoding="utf-8"))
         store[content["$id"]] = content
         store[other.name] = content
+    for common in COMMON_DIR.glob("*.schema.json"):
+        content = json.loads(common.read_text(encoding="utf-8"))
+        store[content["$id"]] = content
+        store[common.name] = content
+        store[f"../common/{common.name}"] = content
     return Draft7Validator(schema, resolver=RefResolver.from_schema(schema, store=store))
 
 

--- a/tools/oma_audit/append.py
+++ b/tools/oma_audit/append.py
@@ -45,6 +45,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AUDIT_SCHEMA_PATH = REPO_ROOT / "schemas" / "audit" / "event.schema.json"
+COMMON_SCHEMA_DIR = REPO_ROOT / "schemas" / "common"
 DEFAULT_AUDIT_LOG = Path(".omao") / "audit.jsonl"
 
 
@@ -54,7 +55,20 @@ class AuditValidationError(ValueError):
 
 def _load_validator() -> Draft202012Validator:
     schema = json.loads(AUDIT_SCHEMA_PATH.read_text(encoding="utf-8"))
-    return Draft202012Validator(schema, format_checker=FormatChecker())
+    try:
+        import referencing
+        from referencing import jsonschema as ref_jsonschema
+
+        resources = []
+        for common in COMMON_SCHEMA_DIR.glob("*.schema.json"):
+            content = json.loads(common.read_text(encoding="utf-8"))
+            resource = ref_jsonschema.DRAFT202012.create_resource(content)
+            resources.append((content["$id"], resource))
+            resources.append((f"../common/{common.name}", resource))
+        registry = referencing.Registry().with_resources(resources)
+        return Draft202012Validator(schema, format_checker=FormatChecker(), registry=registry)
+    except ImportError:
+        return Draft202012Validator(schema, format_checker=FormatChecker())
 
 
 def _iter_errors(event: dict[str, Any]) -> Iterable[str]:

--- a/tools/oma_compile/compile.py
+++ b/tools/oma_compile/compile.py
@@ -39,6 +39,7 @@ from jsonschema import Draft7Validator, RefResolver
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DSL_SCHEMA_PATH = REPO_ROOT / "schemas" / "harness" / "dsl.schema.json"
 ONTOLOGY_SCHEMA_DIR = REPO_ROOT / "schemas" / "ontology"
+COMMON_SCHEMA_DIR = REPO_ROOT / "schemas" / "common"
 TRIGGERS_OUT = REPO_ROOT / ".omao" / "triggers.json"
 
 
@@ -50,6 +51,11 @@ def _build_ref_store() -> dict:
             content = json.loads(schema_path.read_text(encoding="utf-8"))
             store[content["$id"]] = content
             store[f"../ontology/{schema_path.name}"] = content
+    if COMMON_SCHEMA_DIR.exists():
+        for schema_path in COMMON_SCHEMA_DIR.glob("*.schema.json"):
+            content = json.loads(schema_path.read_text(encoding="utf-8"))
+            store[content["$id"]] = content
+            store[f"../common/{schema_path.name}"] = content
     if DSL_SCHEMA_PATH.exists():
         dsl_content = json.loads(DSL_SCHEMA_PATH.read_text(encoding="utf-8"))
         store[dsl_content["$id"]] = dsl_content


### PR DESCRIPTION
## Summary

Consolidate duplicated enum definitions and dead-code `approval-chain.schema.json` into a single-source-of-truth pattern using JSON Schema `$ref`.

## Motivation

Several enumerations (`entityRef`, `blast_radius`, `approval_state`, `phase`) were independently defined in 3–4 schema files. Adding a new ontology entity or enum value required synchronized edits across all copies — easy to miss, resulting in silent drift between schemas.

Additionally, `schemas/common/approval-chain.schema.json` existed but was never actually referenced; Deployment and Incident inlined their own identical copies.

## What changed

### New file
- **`schemas/common/enums.schema.json`** — single source for `entityRef`, `blastRadius`, `approvalState`, `incidentApprovalState`, `aidlcPhase`

### Schema updates (inline → $ref)
| Schema | Fields replaced |
|--------|----------------|
| `ontology/agent.schema.json` | `ontology.produces/consumes` items |
| `ontology/skill.schema.json` | `ontology.produces/consumes/references` items |
| `ontology/deployment.schema.json` | `approval_state`, `blast_radius`, `approval_chain` |
| `ontology/incident.schema.json` | `approval_state`, `blast_radius`, `approval_chain` |
| `audit/event.schema.json` | `target.entity_type`, `phase` |
| `harness/dsl.schema.json` | agent ontology items, policy `phase` items |
| `skill-frontmatter.schema.json` | `ontology` items |

### Tooling updates
- `tools/oma_compile/compile.py` — `_build_ref_store()` now includes `schemas/common/`
- `tools/oma_audit/append.py` — `_load_validator()` registers common schemas via `referencing.Registry`

### Test updates
- 5 test files updated to include `schemas/common/` in their ref stores

## Backward compatibility
- **No semantic change** — the set of valid values for every field remains identical
- **No required-field additions** — no DSL version bump needed
- `agent.schema.json#/definitions/entityRef` kept as a forwarding alias for external consumers that `$ref` it directly

## Verification
- `pytest tests/` → 177 passed
- `oma compile --check` → clean (4 plugins)
