### PR TITLE
fix(harness): wrap plugin hooks.json under a top-level "hooks" key so Claude Code 2.x loads bundled hooks

### DIFF
--- a/plugins/agenticops/hooks/hooks.json
+++ b/plugins/agenticops/hooks/hooks.json
@@ -1,14 +1,16 @@
 {
-  "PreToolUse": [
-    {
-      "_oma": "oma-harness-enforce",
-      "matcher": "Bash|Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "_oma": "oma-harness-enforce",
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/ai-infra/hooks/hooks.json
+++ b/plugins/ai-infra/hooks/hooks.json
@@ -1,25 +1,27 @@
 {
-  "PreToolUse": [
-    {
-      "_oma": "oma-harness-enforce",
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "_oma": "oma-session-start",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-ontology.sh\""
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "_oma": "oma-harness-enforce",
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "_oma": "oma-session-start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-ontology.sh\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/aidlc/hooks/hooks.json
+++ b/plugins/aidlc/hooks/hooks.json
@@ -1,25 +1,27 @@
 {
-  "SessionStart": [
-    {
-      "_oma": "oma-session-start",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-ontology.sh\""
-        }
-      ]
-    }
-  ],
-  "PreToolUse": [
-    {
-      "_oma": "oma-harness-enforce",
-      "matcher": "Bash|Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "_oma": "oma-session-start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-ontology.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "_oma": "oma-harness-enforce",
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/modernization/hooks/hooks.json
+++ b/plugins/modernization/hooks/hooks.json
@@ -1,14 +1,16 @@
 {
-  "PreToolUse": [
-    {
-      "_oma": "oma-harness-enforce",
-      "matcher": "Bash|Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "_oma": "oma-harness-enforce",
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tests/harness/test_session_start_emit.py
+++ b/tests/harness/test_session_start_emit.py
@@ -49,7 +49,7 @@ def test_session_start_entry_emitted(tmp_path):
     compile_plugin(dsl_path, write=True)
     hooks_json = json.loads(
         (dsl_path.parent / "hooks" / "hooks.json").read_text(encoding="utf-8")
-    )
+    )["hooks"]
     assert "SessionStart" in hooks_json
     entry = hooks_json["SessionStart"][0]
     assert entry["_oma"] == SESSION_START_MARKER
@@ -79,9 +79,8 @@ def test_no_hooks_no_session_start(tmp_path):
     compile_plugin(dsl_path, write=True)
     hooks_json_path = dsl_path.parent / "hooks" / "hooks.json"
     if hooks_json_path.exists():
-        assert "SessionStart" not in json.loads(
-            hooks_json_path.read_text(encoding="utf-8")
-        )
+        payload = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        assert "SessionStart" not in payload.get("hooks", {})
 
 
 def test_hand_authored_session_start_preserved(tmp_path):
@@ -95,3 +94,41 @@ def test_hand_authored_session_start_preserved(tmp_path):
     events = payload["SessionStart"]
     assert any(e["hooks"][0]["command"] == "echo hand-authored" for e in events)
     assert any(e.get("_oma") == SESSION_START_MARKER for e in events)
+
+
+def test_emitted_hooks_json_is_wrapped(tmp_path):
+    """The written hooks.json wraps the event map under a top-level "hooks" key,
+    the shape Claude Code's plugin hooks.json loader requires."""
+    dsl_path = _write_plugin(tmp_path, BASE_DSL, hook_body="#!/usr/bin/env bash\n")
+    compile_plugin(dsl_path, write=True)
+    raw = json.loads(
+        (dsl_path.parent / "hooks" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert set(raw.keys()) == {"hooks"}
+    assert "SessionStart" in raw["hooks"]
+
+
+def test_recompile_preserves_wrapper_and_hand_authored(tmp_path):
+    """Recompiling a wrapped hooks.json must stay single-wrapped and keep a
+    hand-authored entry inside the wrapper (unwrap-on-read, wrap-on-write)."""
+    dsl_path = _write_plugin(tmp_path, BASE_DSL, hook_body="#!/usr/bin/env bash\n")
+    compile_plugin(dsl_path, write=True)
+    hooks_path = dsl_path.parent / "hooks" / "hooks.json"
+
+    # Inject a hand-authored SessionStart entry INSIDE the wrapper, as a user would.
+    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    payload["hooks"]["SessionStart"].append(
+        {"hooks": [{"type": "command", "command": "echo hand-authored"}]}
+    )
+    hooks_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    # Recompile: must not double-wrap and must keep the hand-authored entry.
+    compile_plugin(dsl_path, write=True)
+    raw = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert set(raw.keys()) == {"hooks"}  # no double-wrap (no hooks.hooks)
+    commands = [e["hooks"][0]["command"] for e in raw["hooks"]["SessionStart"]]
+    assert "echo hand-authored" in commands
+    assert 'bash "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-ontology.sh"' in commands
+    assert sum(
+        1 for e in raw["hooks"]["SessionStart"] if e.get("_oma") == SESSION_START_MARKER
+    ) == 1

--- a/tests/standalone/run_harness_checks.py
+++ b/tests/standalone/run_harness_checks.py
@@ -172,7 +172,8 @@ def test_compile_us003() -> None:
     hooks_dir = REPO_ROOT / "plugins" / "ai-infra" / "hooks"
     check("US-003 enforce.py bundled", (hooks_dir / "enforce.py").exists())
     check("US-003 harness-rules.json bundled", (hooks_dir / "harness-rules.json").exists())
-    hooks_json = json.loads((hooks_dir / "hooks.json").read_text())
+    # Claude Code plugin hooks.json wraps the event map under a top-level "hooks" key.
+    hooks_json = json.loads((hooks_dir / "hooks.json").read_text())["hooks"]
     cmd = hooks_json["PreToolUse"][0]["hooks"][0]["command"]
     check("US-003 hooks.json refs CLAUDE_PLUGIN_ROOT/hooks/enforce.py",
           "${CLAUDE_PLUGIN_ROOT}/hooks/enforce.py" in cmd, cmd)

--- a/tools/oma_compile/compile.py
+++ b/tools/oma_compile/compile.py
@@ -401,7 +401,14 @@ def _emit_harness(dsl: dict, plugin_dir: Path, source: Path, write: bool) -> lis
 
     existing_hooks = None
     if hooks_json_path.exists():
-        existing_hooks = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        raw_existing = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        # Claude Code plugin hooks.json wraps event maps under a top-level
+        # "hooks" key (same shape as settings.json). Unwrap it so the marker-based
+        # re-own logic in _build_hooks_json operates on the event map directly.
+        if isinstance(raw_existing, dict) and "hooks" in raw_existing:
+            existing_hooks = raw_existing["hooks"]
+        else:
+            existing_hooks = raw_existing
     hooks_payload = _build_hooks_json(dsl, existing_hooks, source)
 
     policies = dsl.get("policies") or []
@@ -427,7 +434,9 @@ def _emit_harness(dsl: dict, plugin_dir: Path, source: Path, write: bool) -> lis
 
     if hooks_payload is not None:
         hooks_dir.mkdir(parents=True, exist_ok=True)
-        _write_json(hooks_json_path, hooks_payload)
+        # Wrap the event map under a top-level "hooks" key — the shape Claude
+        # Code's plugin hooks.json loader requires (mirrors settings.json).
+        _write_json(hooks_json_path, {"hooks": hooks_payload})
         written.append(hooks_json_path)
     elif hooks_json_path.exists():
         # Nothing managed and nothing hand-authored left → remove empty file.


### PR DESCRIPTION
## Summary

Plugin-bundled hooks (`SessionStart`, `PreToolUse`) never loaded in Claude Code
2.1.x. The compiler emitted each plugin's `hooks/hooks.json` with the event names
(`PreToolUse`, `SessionStart`) at the **top level**, but Claude Code's plugin
hook loader requires the event map wrapped under a top-level **`hooks`** key —
the same shape as `settings.json` (`.hooks.SessionStart`). On install, Claude
Code rejected the file and the hooks silently did nothing.

This is a latent defect present since plugin-bundled hooks landed (#60 /
SessionStart, #50 / PreToolUse enforcement) — not a regression introduced here.

---

*Issue #, if available:*

---

*Description of changes:*

## The bug

Installing a plugin whose `hooks.json` used the old shape produced:

```
Failed to load hooks from /Users/.../plugins/aidlc/hooks/hooks.json: [
  {
    "expected": "record",
    "code": "invalid_type",
    "path": ["hooks"],
    "message": "Invalid input: expected record, received undefined"
  }
]
→ Check hooks.json file syntax and structure
```

`path: ["hooks"]` + `expected record, received undefined` = the loader looked for
a top-level `hooks` object and found none.

### Root cause

`settings.json` nests events under a `hooks` key (`.hooks.SessionStart`), and the
plugin `hooks.json` loader expects the same. The compiler was emitting:

```jsonc
// before (rejected by CC 2.x)        // after (loads correctly)
{ "PreToolUse": [...],                { "hooks": {
  "SessionStart": [...] }                 "PreToolUse": [...],
                                          "SessionStart": [...] } }
```

## The fix

`tools/oma_compile/compile.py` (`_emit_harness`) — wrap/unwrap only at the file
boundary; the internal merge logic is untouched:

- **write**: emit `{"hooks": <event map>}`.
- **read (for marker-based re-own)**: if an existing `hooks.json` has a
  top-level `hooks` key, unwrap it first so re-own operates on the event map.
- `_build_hooks_json` is unchanged (still returns an event-keyed dict).
- Double-wrapping (`hooks.hooks`) is prevented and recompiles are idempotent.

Recompiled all four plugins' `hooks.json` into the wrapped shape via
`python -m tools.oma_compile --all`.

## Verification (Claude Code 2.1.214, local marketplace install)

**Before the fix** — `/plugin install aidlc@oh-my-aidlcops` then load fails:

```
1 error:
  Failed to load hooks from /Users/.../plugins/aidlc/hooks/hooks.json: [
    {
      "expected": "record",
      "code": "invalid_type",
      "path": ["hooks"],
      "message": "Invalid input: expected record, received undefined"
    }
  ]
  → Check hooks.json file syntax and structure
```

**After the fix** — same install, hooks load cleanly:

```
aidlc @ oh-my-aidlcops
Scope: user
Version: 0.4.0-preview.1
AIDLC Phase 1 (Inception) + Phase 2 (Construction) opt-in extensions for
awslabs/aidlc-workflows. ...
Author: aws-samples
Status: Enabled · Last used: today

Installed components:
● Skills: ontology-wiki
● Hooks: SessionStart, PreToolUse
```

`● Hooks: SessionStart, PreToolUse` confirms the bundled hooks are now
registered — previously this list was empty because the file was rejected.

## Tests

- `tests/harness/test_session_start_emit.py`
  - read emitted `hooks.json` through `["hooks"]`;
  - `test_emitted_hooks_json_is_wrapped` — the written file has exactly a
    top-level `hooks` key;
  - `test_recompile_preserves_wrapper_and_hand_authored` — recompiling stays
    single-wrapped (no `hooks.hooks`) and keeps a hand-authored entry inside the
    wrapper.
- `tests/standalone/run_harness_checks.py` — read `hooks.json` through `["hooks"]`.

Results: pytest 121 passed · `oma compile --all --check` clean (4 plugins) ·
standalone harness checks 34/34.

## Changed files

```
tools/oma_compile/compile.py              (+13/-2)  wrap on write, unwrap on read
plugins/ai-infra/hooks/hooks.json         recompiled → wrapped
plugins/agenticops/hooks/hooks.json       recompiled → wrapped
plugins/aidlc/hooks/hooks.json            recompiled → wrapped
plugins/modernization/hooks/hooks.json    recompiled → wrapped
tests/harness/test_session_start_emit.py  wrapper access + regressions
tests/standalone/run_harness_checks.py    wrapper access
```

## Compatibility

- No DSL / `*.oma.yaml` source changes — only the emitted `hooks.json` shape and
  the compiler that writes it. Re-running `oma compile` on any existing plugin
  produces the wrapped shape.
- The unwrap-on-read path keeps marker-based re-own working for both the old
  (top-level) and new (wrapped) on-disk shapes, so a mixed checkout recompiles
  cleanly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
