### PR TITLE
feat(harness): enforce AIDLC phase gates at turn-end via Stop/StopFailure hooks

### DIFF
--- a/docs/docs/harness-dsl-v2.md
+++ b/docs/docs/harness-dsl-v2.md
@@ -131,6 +131,58 @@ skipped without disabling the others.
 `skill_ref` is **not** validated against the plugin file — skills are
 resolved at runtime by the harness.
 
+## Hook events (`hooks:`)
+
+The `hooks:` block declares plugin-bundled hooks the compiler emits into
+`hooks/hooks.json`. Each key is an event; `runs` is a script path that must stay
+inside the plugin root (so `/plugin install` ships it — a `../`-escaping path is
+a compile error). `PreToolUse` is **not** declared here; it is derived from the
+`policies:` block above.
+
+| Event | Emitted as | Bundled script | Purpose |
+|-------|-----------|----------------|---------|
+| `session-start` | `SessionStart` | `session-start-ontology.sh` | Inject active ontology state (Budgets, Incidents, Deployments) at session start |
+| `stop` | `Stop` | `stop-gate.sh` | Turn-end phase-gate enforcement — block the turn from ending while a gate is blocked |
+| `stop-failure` | `StopFailure` | `stop-gate.sh` | Remind about blocked gates on a failed turn (never blocks) |
+
+```yaml
+hooks:
+  session-start:
+    runs: hooks/session-start-ontology.sh
+  stop:
+    runs: hooks/stop-gate.sh
+  stop-failure:
+    runs: hooks/stop-gate.sh
+```
+
+### Phase-gate enforcement (`stop` / `stop-failure`)
+
+The `quality-gates` skill writes a per-phase verdict to
+`.omao/state/gates/<phase>.json` (`status: passed|blocked`,
+`next_phase_allowed`, `blockers`, waiver reconciliation). `stop-gate.sh` is the
+**enforcement half**: it does not re-derive the verdict, it trusts the recorded
+one. When any gate is blocked (`status == "blocked"` or
+`next_phase_allowed == false`):
+
+- **`Stop`** returns `{"decision": "block", "reason": ...}` so the turn cannot
+  end — the agent that authored the work cannot silently skip its own gate
+  (the self-grading failure mode).
+- **`StopFailure`** never blocks (that would trap a failing session in a loop);
+  it surfaces a `systemMessage` reminder only.
+
+Controls:
+
+- `OMA_GATE_MODE=warn` — downgrade the `Stop` block to a non-blocking
+  `systemMessage`.
+- `OMA_DISABLE_GATES=1` — kill switch; the hook always passes through.
+- Reentry guard — Claude Code sets `stop_hook_active: true` when it re-runs the
+  Stop hook after a prior block; the hook passes through in that case to avoid a
+  deadlock.
+
+Like `session-start-ontology.sh`, the script is self-contained (reads only
+`.omao/state/gates/`, no repo-root dependency) and requires a real JSON encoder
+(`jq`, then `python3`) so user-editable gate files cannot inject keys.
+
 ## Backward compatibility guarantees
 
 - v1 files continue to validate under the same `dsl.schema.json`.

--- a/docs/docs/harness-engineering.md
+++ b/docs/docs/harness-engineering.md
@@ -41,7 +41,7 @@ today — and, honestly, where it does not yet.
 |---|---|---|---|
 | **Retry Budget** | cap retries (e.g. 847 → 3) | `Budget.rule_expression` + `cost-governance` breach actions | ✅ |
 | **Cost Limit** | per-request/period spend caps | `Budget` entity (`limit_usd`, `period`, `action_on_breach`); sandboxed `simpleeval` evaluator | ✅ |
-| **Output Gate** | block incomplete/harmful output | `aidlc` → `construction/quality-gates` skill | ✅ |
+| **Output Gate** | block incomplete/harmful output | `aidlc` → `construction/quality-gates` skill (verdict) + bundled `Stop` hook (`stop-gate.sh`, turn-end enforcement) | ✅ |
 | **PII Masking** | protect sensitive data in/out/logs | `ai-infra` → `ai-gateway-guardrails` skill | ✅ |
 | **Prompt Injection Defense** | instruction hierarchy, delimiter isolation | `ai-gateway-guardrails` skill | ✅ |
 | **Timeout** | prevent infinite loops | Harness DSL `timeout` field | ⚠️ partial (declared in DSL; runtime enforcement evolving) |
@@ -93,6 +93,14 @@ early before they propagate downstream.
 OMA reflects this in its review lane: distinct reviewer roles (security, quality,
 code) run as separate agents, and `continuous-eval` re-checks deployed behavior
 against regression datasets rather than trusting the generating agent's own tests.
+
+The `Stop` hook (`stop-gate.sh`) closes a subtler gap: even with independent
+reviewers, the *generating* agent decides when a turn is done. When
+`quality-gates` records a blocked verdict in `.omao/state/gates/<phase>.json`,
+the Stop hook blocks the turn from ending at the harness level — so the agent
+that authored the work cannot silently declare victory past its own gate.
+`OMA_GATE_MODE=warn` downgrades this to a reminder; `OMA_DISABLE_GATES=1`
+disables it. See [Harness DSL v2 → Phase-gate enforcement](./harness-dsl-v2.md#phase-gate-enforcement-stop--stop-failure).
 
 ## How the two axes close the loop
 

--- a/plugins/aidlc/aidlc.oma.yaml
+++ b/plugins/aidlc/aidlc.oma.yaml
@@ -85,15 +85,26 @@ policies:
       decision: deny
       reason: "Harness: writing secret-bearing files via the shell is blocked. Use a secrets manager (e.g. External Secrets, SSM) instead of committing secrets."
 # ---------------------------------------------------------------------------
-# Hooks — plugin-bundled, self-contained SessionStart (#60).
-# Injects active ontology state (.omao/ontology) at session start. Bundled
-# INSIDE the plugin so /plugin install ships it (the repo-root
-# hooks/session-start.sh is the richer CLI/dev-install variant). The compiler
-# emits the SessionStart entry into hooks/hooks.json from this declaration.
+# Hooks — plugin-bundled, self-contained.
+#   session-start: injects active ontology state (.omao/ontology) at session
+#     start (#60).
+#   stop / stop-failure: phase-gate enforcement. The quality-gates skill writes
+#     a verdict to .omao/state/gates/<phase>.json; stop-gate.sh reads that
+#     verdict and, on a blocked gate, blocks the turn from ending (Stop) or
+#     surfaces a reminder (StopFailure). Turn-end enforcement of the same gate
+#     the skill defines, so the agent that authored the work cannot silently
+#     skip it (the self-grading failure mode). Controls: OMA_GATE_MODE=warn
+#     downgrades block -> warning; OMA_DISABLE_GATES=1 disables.
+# All bundled INSIDE the plugin so /plugin install ships them. The compiler
+# emits the matching hooks/hooks.json entries from these declarations.
 # ---------------------------------------------------------------------------
 hooks:
   session-start:
     runs: hooks/session-start-ontology.sh
+  stop:
+    runs: hooks/stop-gate.sh
+  stop-failure:
+    runs: hooks/stop-gate.sh
 
 triggers:
   - id: inception

--- a/plugins/aidlc/hooks/hooks.json
+++ b/plugins/aidlc/hooks/hooks.json
@@ -21,5 +21,27 @@
         }
       ]
     }
+  ],
+  "Stop": [
+    {
+      "_oma": "oma-stop-gate",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh\""
+        }
+      ]
+    }
+  ],
+  "StopFailure": [
+    {
+      "_oma": "oma-stop-failure-gate",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh\""
+        }
+      ]
+    }
   ]
 }

--- a/plugins/aidlc/hooks/stop-gate.sh
+++ b/plugins/aidlc/hooks/stop-gate.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# stop-gate.sh — plugin-bundled Stop / StopFailure hook (harness safety axis).
+#
+# Enforces AIDLC phase gates at turn-end. The quality-gates skill writes a
+# verdict per phase to .omao/state/gates/<phase>.json:
+#
+#   { "phase": "...", "status": "passed|blocked", "next_phase_allowed": bool,
+#     "blockers": [...], "waiver_ref": null|"..." }
+#
+# This hook is the ENFORCEMENT half: it does not re-derive the verdict (the
+# skill already reconciles waivers/TTL), it only trusts the recorded verdict.
+# If any gate is blocked (status=blocked OR next_phase_allowed=false) it stops
+# Claude from ending the turn, so a gate cannot be silently skipped by the same
+# agent that authored the work — the self-grading failure mode OMA targets.
+#
+# EVENTS (one script, two events; distinguished by stdin hook_event_name):
+#   Stop         — a completed turn. In block mode a blocked gate returns
+#                  {"decision":"block", ...} so the turn is not allowed to end.
+#   StopFailure  — a failed turn. NEVER blocks (that would trap a failing
+#                  session in a loop). Surfaces a systemMessage reminder only.
+#
+# SELF-CONTAINED BY DESIGN (same contract as session-start-ontology.sh): reads
+# ONLY the project's .omao/state/gates/ and has NO repo-root dependency, so it
+# works verbatim from an installed plugin copy.
+#
+# REENTRY GUARD: Claude Code sets stdin.stop_hook_active=true when it re-runs
+# the Stop hook after a prior block. If we blocked again we would deadlock the
+# session, so we pass through immediately in that case.
+#
+# CONTROLS:
+#   OMA_DISABLE_GATES=1   kill switch — always pass through (no-op).
+#   OMA_GATE_MODE=warn    downgrade block -> non-blocking systemMessage.
+#                         Default (unset/anything else) is block.
+#
+# Emitted into hooks/hooks.json (Stop / StopFailure) by oma-compile from the
+# DSL `hooks.stop` / `hooks.stop-failure` declarations. Do not hand-edit those
+# hooks.json entries; edit the DSL and recompile.
+
+set -euo pipefail
+
+# A real JSON encoder is REQUIRED: gate files are user-editable and may contain
+# quotes/newlines that naive shell interpolation would turn into key injection.
+_emit_pass() {
+  # An empty, valid payload the harness reads as a no-op (do not block).
+  printf '{}\n'
+  exit 0
+}
+
+_emit_json() {
+  # $1 = event name, $2 = mode ("block"|"warn"), $3 = reason/message text.
+  local event="$1" mode="$2" text="$3"
+  if command -v jq >/dev/null 2>&1; then
+    if [[ "$mode" == "block" ]]; then
+      jq -n --arg reason "$text" '{decision: "block", reason: $reason}'
+    else
+      jq -n --arg msg "$text" '{systemMessage: $msg}'
+    fi
+  elif command -v python3 >/dev/null 2>&1; then
+    OMA_TEXT="$text" OMA_MODE="$mode" python3 -c '
+import json, os, sys
+text = os.environ["OMA_TEXT"]
+if os.environ["OMA_MODE"] == "block":
+    out = {"decision": "block", "reason": text}
+else:
+    out = {"systemMessage": text}
+sys.stdout.write(json.dumps(out)); sys.stdout.write("\n")
+'
+  else
+    echo "stop-gate.sh: neither jq nor python3 available; refusing to emit unsafe JSON" >&2
+    exit 1
+  fi
+  exit 0
+}
+
+# Kill switch.
+if [[ "${OMA_DISABLE_GATES:-0}" == "1" ]]; then
+  _emit_pass
+fi
+
+# Read the event payload once from stdin.
+INPUT="$(cat 2>/dev/null || true)"
+
+# Determine the event and the reentry flag. Fall back gracefully when jq is
+# absent (grep the raw JSON) so the reentry guard never fails open into a loop.
+EVENT=""
+STOP_ACTIVE="false"
+if command -v jq >/dev/null 2>&1 && [[ -n "$INPUT" ]]; then
+  EVENT="$(printf '%s' "$INPUT" | jq -r '.hook_event_name // ""' 2>/dev/null || echo "")"
+  STOP_ACTIVE="$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")"
+else
+  # Best-effort textual detection without jq.
+  case "$INPUT" in
+    *'"stop_hook_active"'*'true'*) STOP_ACTIVE="true" ;;
+  esac
+  case "$INPUT" in
+    *'"hook_event_name"'*StopFailure*) EVENT="StopFailure" ;;
+    *'"hook_event_name"'*Stop*)        EVENT="Stop" ;;
+  esac
+fi
+
+# Reentry guard: never block a turn that is already re-running after a block.
+if [[ "$STOP_ACTIVE" == "true" ]]; then
+  _emit_pass
+fi
+
+# Resolve the project directory. Claude Code passes CLAUDE_PROJECT_DIR to hooks
+# (the cwd at `claude` startup); fall back to $PWD for other harnesses.
+OMA_PROJ_DIR="${CLAUDE_PROJECT_DIR:-${OMA_PROJECT_DIR:-$PWD}}"
+GATES_DIR="$OMA_PROJ_DIR/.omao/state/gates"
+
+# No gate directory → nothing to enforce.
+if [[ ! -d "$GATES_DIR" ]]; then
+  _emit_pass
+fi
+
+# Collect blocked gates. A gate is blocked when status=blocked OR
+# next_phase_allowed=false. We need jq for a trustworthy read; without it we
+# cannot safely parse user JSON, so we pass through (the PreToolUse enforcer
+# remains the hard backstop; this hook is a turn-end gate check).
+if ! command -v jq >/dev/null 2>&1; then
+  _emit_pass
+fi
+
+BLOCKED_LINES=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  line="$(jq -r '
+    select(.status == "blocked" or .next_phase_allowed == false)
+    | "\(.phase // "?"): \((.blockers // []) | if length == 0 then "gate blocked" else join("; ") end)"
+  ' "$f" 2>/dev/null || true)"
+  [[ -n "$line" ]] && BLOCKED_LINES+="  - $line"$'\n'
+done < <(find "$GATES_DIR" -maxdepth 1 -type f -name '*.json' 2>/dev/null)
+
+# No blocked gate → allow the turn to end.
+if [[ -z "$BLOCKED_LINES" ]]; then
+  _emit_pass
+fi
+
+# Mode: default block, opt-in warn.
+MODE="block"
+[[ "${OMA_GATE_MODE:-block}" == "warn" ]] && MODE="warn"
+
+if [[ "$EVENT" == "StopFailure" ]]; then
+  # A failed turn must never be blocked (that would trap the session). Remind
+  # only, regardless of MODE.
+  _emit_json "StopFailure" "warn" "[OMA gate] The turn failed while AIDLC phase gate(s) are blocked:
+$BLOCKED_LINES
+Resolve the blockers, or add a signed waiver under .omao/state/gates/waivers/, before proceeding. Run the quality-gates skill to re-evaluate."
+fi
+
+# Stop event with a blocked gate.
+if [[ "$MODE" == "block" ]]; then
+  _emit_json "Stop" "block" "[OMA gate] Cannot end the turn: AIDLC phase gate(s) are blocked:
+$BLOCKED_LINES
+Resolve the blockers, or add a signed waiver under .omao/state/gates/waivers/, then re-run the quality-gates skill. Set OMA_GATE_MODE=warn to downgrade this to a warning, or OMA_DISABLE_GATES=1 to disable gate enforcement."
+else
+  _emit_json "Stop" "warn" "[OMA gate] AIDLC phase gate(s) are blocked (warn mode):
+$BLOCKED_LINES
+Consider resolving before proceeding. Run the quality-gates skill to re-evaluate."
+fi

--- a/schemas/harness/dsl.schema.json
+++ b/schemas/harness/dsl.schema.json
@@ -63,7 +63,7 @@
       "additionalProperties": { "$ref": "#/definitions/mcpServer" }
     },
     "hooks": {
-      "description": "Harness hooks. Keys are Claude Code hook event names (session-start, pre-tool-use, ...).",
+      "description": "Harness hooks keyed by event name. The compiler emits a plugin-bundled hooks/hooks.json entry for each recognized event: session-start (ontology-state injection), stop and stop-failure (turn-end phase-gate enforcement via the bundled stop-gate.sh). Each runs path must stay inside the plugin root. PreToolUse is not declared here — it is derived from the policies: block.",
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/hook" }
     },

--- a/tests/harness/test_stop_hook_emit.py
+++ b/tests/harness/test_stop_hook_emit.py
@@ -1,0 +1,125 @@
+"""Compiler Stop / StopFailure emission tests.
+
+The compiler emits plugin-bundled Stop and StopFailure entries into
+hooks/hooks.json from DSL `hooks.stop.runs` / `hooks.stop-failure.runs`
+declarations, so /plugin install delivers phase-gate enforcement. Each event
+re-owns only its own _oma-marked entry, so hand-authored entries in the same
+group survive recompiles. The runs path must stay inside the plugin root (the
+same plugin-escape guard as SessionStart).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.oma_compile.compile import (
+    STOP_FAILURE_MARKER,
+    STOP_MARKER,
+    CompileError,
+    _build_hooks_json,
+    compile_plugin,
+)
+
+
+def _write_plugin(root: Path, dsl: dict) -> Path:
+    plugin_dir = root / "plugins" / dsl["plugin"]
+    (plugin_dir / "hooks").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "hooks" / "stop-gate.sh").write_text(
+        "#!/usr/bin/env bash\n", encoding="utf-8"
+    )
+    out = plugin_dir / f"{dsl['plugin']}.oma.yaml"
+    out.write_text(yaml.safe_dump(dsl, sort_keys=False), encoding="utf-8")
+    return out
+
+
+BASE_DSL = {
+    "version": 2,
+    "plugin": "x-plugin",
+    "mcp": {},
+    "agents": [],
+    "hooks": {
+        "stop": {"runs": "hooks/stop-gate.sh"},
+        "stop-failure": {"runs": "hooks/stop-gate.sh"},
+    },
+}
+
+
+def test_stop_and_stop_failure_entries_emitted(tmp_path):
+    dsl_path = _write_plugin(tmp_path, BASE_DSL)
+    compile_plugin(dsl_path, write=True)
+    hooks_json = json.loads(
+        (dsl_path.parent / "hooks" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert hooks_json["Stop"][0]["_oma"] == STOP_MARKER
+    assert hooks_json["StopFailure"][0]["_oma"] == STOP_FAILURE_MARKER
+    expected_cmd = 'bash "${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh"'
+    assert hooks_json["Stop"][0]["hooks"][0]["command"] == expected_cmd
+    assert hooks_json["StopFailure"][0]["hooks"][0]["command"] == expected_cmd
+
+
+def test_stop_only_does_not_emit_stop_failure(tmp_path):
+    dsl = dict(BASE_DSL)
+    dsl["hooks"] = {"stop": {"runs": "hooks/stop-gate.sh"}}
+    dsl_path = _write_plugin(tmp_path, dsl)
+    compile_plugin(dsl_path, write=True)
+    hooks_json = json.loads(
+        (dsl_path.parent / "hooks" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert "Stop" in hooks_json
+    assert "StopFailure" not in hooks_json
+
+
+def test_escaping_runs_path_rejected(tmp_path):
+    """A stop runs path that escapes the plugin root is a compile error."""
+    dsl = dict(BASE_DSL)
+    dsl["hooks"] = {"stop": {"runs": "../../hooks/stop-gate.sh"}}
+    dsl_path = _write_plugin(tmp_path, dsl)
+    # Create the escaping target so _verify_hooks passes and the failure is
+    # specifically the plugin-escape guard in the emitter (not "missing script").
+    (tmp_path / "hooks").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "hooks" / "stop-gate.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    with pytest.raises(CompileError, match="escapes the plugin root"):
+        compile_plugin(dsl_path, write=True)
+
+
+def test_hand_authored_stop_preserved(tmp_path):
+    """A non-managed Stop entry survives recompiles (per-event marker re-own)."""
+    existing = {
+        "Stop": [
+            {"hooks": [{"type": "command", "command": "echo hand-authored"}]},
+            {"_oma": STOP_MARKER, "hooks": [{"type": "command", "command": "STALE"}]},
+        ]
+    }
+    payload = _build_hooks_json(BASE_DSL, existing, tmp_path / "x.oma.yaml")
+    commands = [e["hooks"][0]["command"] for e in payload["Stop"]]
+    assert "echo hand-authored" in commands
+    assert 'bash "${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh"' in commands
+    assert "STALE" not in commands
+    assert sum(1 for e in payload["Stop"] if e.get("_oma") == STOP_MARKER) == 1
+
+
+def test_dropping_stop_removes_managed_keeps_hand_authored(tmp_path):
+    existing = {
+        "Stop": [
+            {"hooks": [{"type": "command", "command": "echo hand-authored"}]},
+            {"_oma": STOP_MARKER, "hooks": [{"type": "command", "command": "STALE"}]},
+        ]
+    }
+    dsl = {"version": 2, "plugin": "x-plugin", "hooks": {}}
+    payload = _build_hooks_json(dsl, existing, tmp_path / "x.oma.yaml")
+    commands = [e["hooks"][0]["command"] for e in payload["Stop"]]
+    assert commands == ["echo hand-authored"]
+
+
+def test_timeout_ms_passthrough(tmp_path):
+    dsl = {
+        "version": 2,
+        "plugin": "x-plugin",
+        "hooks": {"stop": {"runs": "hooks/stop-gate.sh", "timeout_ms": 5000}},
+    }
+    payload = _build_hooks_json(dsl, None, tmp_path / "x.oma.yaml")
+    assert payload["Stop"][0]["hooks"][0]["timeout"] == 5000

--- a/tests/hooks/test_stop_gate.bats
+++ b/tests/hooks/test_stop_gate.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/hooks/test_stop_gate.bats
+#
+# Behavioral tests for the plugin-bundled Stop / StopFailure phase-gate hook.
+# The hook reads .omao/state/gates/<phase>.json verdicts (written by the
+# quality-gates skill) and enforces them at turn-end.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK="$REPO_ROOT/plugins/aidlc/hooks/stop-gate.sh"
+    PROJECT="$(mktemp -d)"
+    mkdir -p "$PROJECT/.omao/state/gates"
+}
+
+teardown() {
+    rm -rf "$PROJECT"
+}
+
+_write_blocked_gate() {
+    cat > "$PROJECT/.omao/state/gates/construction.json" <<'JSON'
+{
+  "phase": "construction",
+  "status": "blocked",
+  "blockers": ["risk-discovery category 2 (Security) BLOCK: plaintext secret in configmap"],
+  "next_phase_allowed": false
+}
+JSON
+}
+
+_write_passed_gate() {
+    cat > "$PROJECT/.omao/state/gates/inception.json" <<'JSON'
+{ "phase": "inception", "status": "passed", "next_phase_allowed": true, "blockers": [] }
+JSON
+}
+
+@test "Stop + blocked gate: blocks the turn (default block mode)" {
+    _write_blocked_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.decision == "block"' >/dev/null
+    echo "$output" | jq -e '.reason | contains("construction")' >/dev/null
+}
+
+@test "Stop + blocked gate + OMA_GATE_MODE=warn: warns, does not block" {
+    _write_blocked_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" OMA_GATE_MODE=warn bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    # jq -e exits non-zero on false, so the combined predicate covers both:
+    # no decision key AND a systemMessage mentioning the block.
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+    echo "$output" | jq -e '.systemMessage | contains("blocked")' >/dev/null
+}
+
+@test "StopFailure + blocked gate: never blocks, reminder only" {
+    _write_blocked_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"StopFailure"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+    echo "$output" | jq -e '.systemMessage | contains("failed")' >/dev/null
+}
+
+@test "Stop + only passed gates: allows the turn" {
+    _write_passed_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+}
+
+@test "reentry guard: stop_hook_active=true passes through even when blocked" {
+    _write_blocked_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop","stop_hook_active":true}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+}
+
+@test "OMA_DISABLE_GATES=1 passes through even when blocked" {
+    _write_blocked_gate
+    run env CLAUDE_PROJECT_DIR="$PROJECT" OMA_DISABLE_GATES=1 bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+}
+
+@test "next_phase_allowed=false alone (status omitted) blocks" {
+    cat > "$PROJECT/.omao/state/gates/construction.json" <<'JSON'
+{ "phase": "construction", "next_phase_allowed": false, "blockers": [] }
+JSON
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.decision == "block"' >/dev/null
+    # Empty blockers array degrades to a generic "gate blocked" message.
+    echo "$output" | jq -e '.reason | contains("gate blocked")' >/dev/null
+}
+
+@test "no gates directory: hook passes through" {
+    rm -rf "$PROJECT/.omao/state/gates"
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("decision") | not' >/dev/null
+}
+
+@test "crafted blocker text does not break JSON (injection safety)" {
+    cat > "$PROJECT/.omao/state/gates/construction.json" <<'JSON'
+{ "phase": "construction", "status": "blocked", "blockers": ["evil \"quote\" and\nnewline"], "next_phase_allowed": false }
+JSON
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<'{"hook_event_name":"Stop"}'
+    [ "$status" -eq 0 ]
+    # Output must remain valid JSON with a single decision key.
+    echo "$output" | jq -e '.decision == "block"' >/dev/null
+}

--- a/tools/oma_compile/compile.py
+++ b/tools/oma_compile/compile.py
@@ -297,11 +297,20 @@ HARNESS_HOOK_MARKER = "oma-harness-enforce"
 # Marker for the compiler-managed SessionStart entry (#60). Same re-own pattern
 # as the harness marker so hand-authored SessionStart hooks are preserved.
 SESSION_START_MARKER = "oma-session-start"
+# Markers for the compiler-managed Stop / StopFailure entries (phase-gate
+# enforcement). Each event carries its own marker so re-own stays scoped per
+# event and hand-authored entries in any of these groups survive recompiles.
+STOP_MARKER = "oma-stop-gate"
+STOP_FAILURE_MARKER = "oma-stop-failure-gate"
 
 # DSL hook events the compiler emits into hooks/hooks.json, mapped to the
-# Claude Code hook event name. PreToolUse is handled separately (it is derived
-# from policies:, not from a hooks: declaration).
-_EMITTABLE_HOOK_EVENTS = {"session-start": "SessionStart"}
+# (Claude Code hook event name, re-own marker) it manages. PreToolUse is handled
+# separately (it is derived from policies:, not from a hooks: declaration).
+_EMITTABLE_HOOK_EVENTS = {
+    "session-start": ("SessionStart", SESSION_START_MARKER),
+    "stop": ("Stop", STOP_MARKER),
+    "stop-failure": ("StopFailure", STOP_FAILURE_MARKER),
+}
 
 
 def _plugin_relative_hook_command(runs: str, source: Path) -> str:
@@ -328,8 +337,9 @@ def _build_hooks_json(dsl: dict, existing: dict | None, source: Path) -> dict | 
     Manages two entry kinds, both re-owned via an _oma marker so hand-authored
     entries survive recompiles:
       * PreToolUse — the harness enforcer, emitted when policies: is present.
-      * SessionStart — emitted when hooks.session-start.runs is declared (#60),
-        so ontology-state injection ships inside the plugin.
+      * SessionStart / Stop / StopFailure — emitted when the matching
+        hooks.<event>.runs is declared, so ontology-state injection (#60) and
+        phase-gate enforcement ship inside the plugin.
 
     Returns the new payload, or None when nothing is managed and nothing was
     hand-authored.
@@ -356,18 +366,20 @@ def _build_hooks_json(dsl: dict, existing: dict | None, source: Path) -> dict | 
     else:
         payload.pop("PreToolUse", None)
 
-    # SessionStart (and any other emittable hooks:) — from the hooks: block.
+    # SessionStart / Stop / StopFailure (and any other emittable hooks:) — from
+    # the hooks: block. Each event re-owns only its own marked entry, so
+    # hand-authored entries in the same group survive recompiles.
     hooks = dsl.get("hooks") or {}
-    for event, cc_event in _EMITTABLE_HOOK_EVENTS.items():
+    for event, (cc_event, marker) in _EMITTABLE_HOOK_EVENTS.items():
         managed = [
             e for e in (payload.get(cc_event) or [])
-            if e.get("_oma") != SESSION_START_MARKER
+            if e.get("_oma") != marker
         ]
         spec = hooks.get(event) or {}
         runs = spec.get("runs")
         if runs:
             entry = {
-                "_oma": SESSION_START_MARKER,
+                "_oma": marker,
                 "hooks": [{
                     "type": "command",
                     "command": _plugin_relative_hook_command(runs, source),


### PR DESCRIPTION
## Summary

Adds a plugin-bundled `Stop` / `StopFailure` hook to the `aidlc` plugin so a
**blocked AIDLC phase gate cannot be silently skipped by the agent that authored
the work** — closing the self-grading gap that the `PreToolUse` policy enforcer
does not cover.

The `quality-gates` skill already records a per-phase verdict to
`.omao/state/gates/<phase>.json`. This PR adds the *enforcement half*: at
turn-end, the hook reads that recorded verdict and, when a gate is blocked, stops
the turn from ending. The hook does **not** re-derive the verdict (the skill
already reconciles waivers/TTL) — it only trusts and enforces it, keeping the
"grader" and the "worker" separate.

## Why

The methodology's sharpest rule is *"tests written by the same agent that wrote
the code cannot catch that agent's errors."* Even with independent reviewers, the
generating agent still decides when its turn is done — and can end the turn past
its own unmet gate. A `Stop` hook is the only place to enforce "you cannot finish
while a gate is blocked" at the harness level, where prompt guidance alone is
insufficient.

## What it does

| Event | Trigger | Behavior |
|-------|---------|----------|
| `Stop` | a completed turn | If any gate is blocked (`status == "blocked"` OR `next_phase_allowed == false`), returns `{"decision":"block", ...}` so the turn cannot end (default). |
| `StopFailure` | a failed turn | **Never blocks** (that would trap a failing session in a loop); surfaces a `systemMessage` reminder only. |

Controls:

- `OMA_GATE_MODE=warn` — downgrade the `Stop` block to a non-blocking
  `systemMessage`.
- `OMA_DISABLE_GATES=1` — kill switch; the hook always passes through.
- **Reentry guard** — Claude Code sets `stop_hook_active: true` when it re-runs
  the Stop hook after a prior block; the hook then passes through, so the turn is
  extended **at most once** and never deadlocks.

The decision is driven by `status` / `next_phase_allowed`; `blockers` is only the
human-readable reason shown in the block message.

---

*Issue #, if available:*

---

*Description of changes:*


## Implementation

- **`plugins/aidlc/hooks/stop-gate.sh`** (new) — self-contained: reads only
  `.omao/state/gates/`, no repo-root dependency, so it works verbatim from an
  installed plugin copy. Distinguishes `Stop` vs `StopFailure` from the stdin
  `hook_event_name`. Requires a real JSON encoder (`jq`, then `python3`) so
  user-editable gate files cannot inject keys into the emitted payload.
- **`tools/oma_compile/compile.py`** — `_EMITTABLE_HOOK_EVENTS` becomes an
  `{event: (cc_event, marker)}` map; adds `stop → Stop` and
  `stop-failure → StopFailure`, each with its own `_oma` marker so marker-based
  re-own stays scoped per event (hand-authored entries in the same group survive
  recompiles).
- **`plugins/aidlc/aidlc.oma.yaml`** — declares `hooks.stop` / `hooks.stop-failure`;
  `hooks.json` recompiled.
- **schema + docs** — document the new hook events and phase-gate enforcement.

## Tests

- `tests/harness/test_stop_hook_emit.py` — 6 compiler-emit cases (both events
  emitted, per-event re-own preserves hand-authored entries, plugin-escape guard,
  `timeout_ms` passthrough).
- `tests/hooks/test_stop_gate.bats` — 9 behavior cases: block on blocked gate,
  `OMA_GATE_MODE=warn` downgrade, `StopFailure` never blocks, passed-gate allows,
  reentry guard, `OMA_DISABLE_GATES=1`, `next_phase_allowed=false` alone,
  no-gates-dir passthrough, injection-safe JSON.

Results: pytest (harness) green · bats 9/9 · `oma compile --all --check` clean.

## Dependency / ordering note

This branch's emitted `hooks.json` uses the historical top-level event-name shape
(`{"Stop": [...], ...}`). Claude Code 2.1.x requires the event map wrapped under
a top-level `hooks` key, so on its own the bundled hooks are rejected at install
time. That wrapper fix is a **separate, orthogonal change** (see the companion
`fix(harness): wrap plugin hooks.json under a top-level "hooks" key` PR). Once
both land, recompiling produces the wrapped shape and these Stop/StopFailure
entries load correctly — verified in Claude Code 2.1.214 with the wrapper fix
applied (`● Hooks: ... Stop, StopFailure` registered on install).

Recommended merge order: land the `hooks.json` wrapper fix first (or fold this
branch on top of it), then this feature, so `main` never carries a `hooks.json`
that CC 2.x rejects.

## Changed files

```
plugins/aidlc/hooks/stop-gate.sh          (new)   self-contained Stop/StopFailure hook
tools/oma_compile/compile.py                       emit stop / stop-failure events
plugins/aidlc/aidlc.oma.yaml                       declare hooks.stop / hooks.stop-failure
plugins/aidlc/hooks/hooks.json                     recompiled (Stop, StopFailure entries)
schemas/harness/dsl.schema.json                    document hook events
docs/docs/harness-dsl-v2.md                        Phase-gate enforcement section
docs/docs/harness-engineering.md                   self-grading / Output Gate note
tests/harness/test_stop_hook_emit.py      (new)    6 compiler-emit tests
tests/hooks/test_stop_gate.bats           (new)    9 behavior tests
```

## Compatibility

- New DSL hook events are additive; plugins without `hooks.stop` /
  `hooks.stop-failure` are unaffected.
- Absent `.omao/state/gates/`, the hook passes through (no-op), so projects that
  do not use phase gates see no behavior change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
