### PR TITLE
feat(harness): audit every tool call via a PostToolUse hook in agenticops

### DIFF
--- a/docs/docs/harness-dsl-v2.md
+++ b/docs/docs/harness-dsl-v2.md
@@ -131,6 +131,55 @@ skipped without disabling the others.
 `skill_ref` is **not** validated against the plugin file — skills are
 resolved at runtime by the harness.
 
+## Hook events (`hooks:`)
+
+The `hooks:` block declares plugin-bundled hooks the compiler emits into
+`hooks/hooks.json`. Each key is an event; `runs` is a script path that must stay
+inside the plugin root (so `/plugin install` ships it — a `../`-escaping path is
+a compile error). `PreToolUse` is **not** declared here; it is derived from the
+`policies:` block above, and coexists with a hooks-declared `PostToolUse` (each
+re-owns only its own `_oma`-marked entry).
+
+| Event | Emitted as | Bundled script | Purpose |
+|-------|-----------|----------------|---------|
+| `session-start` | `SessionStart` | `session-start-ontology.sh` | Inject active ontology state (Budgets, Incidents, Deployments) at session start |
+| `post-tool-use` | `PostToolUse` | `audit-posttooluse.sh` | Audit every tool call; nudge on state-changing calls |
+
+```yaml
+hooks:
+  post-tool-use:
+    runs: hooks/audit-posttooluse.sh
+```
+
+### Tool-call auditing (`post-tool-use`)
+
+`audit-posttooluse.sh` runs after every tool call and does two things:
+
+- **Audit (all tools)** — appends one JSON-L line per call to
+  `.omao/audit/tool-events.jsonl`, conforming to
+  [`schemas/audit/tool-event.schema.json`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/schemas/audit/tool-event.schema.json).
+  This makes the audit trail a property of the harness rather than of the agent
+  remembering to invoke the `audit-trail` skill. The tool-event schema is
+  self-contained (no `$ref`) so the hook emits conforming lines with just `jq`
+  (or `python3`) — no `jsonschema` dependency inside the installed plugin.
+- **Feedback (state-changing calls only)** — for mutating patterns (mutating
+  `kubectl`, `aws` delete/put/update/…, `terraform apply|destroy`, `helm`
+  install/upgrade/…, `rm|mv|cp|…`, `git push|reset|…`, `Write`, `Edit`), returns
+  a non-blocking `additionalContext` nudge to record the semantic ontology event
+  and check that no phase gate is blocked. `PostToolUse` runs *after* the tool,
+  so it cannot block — the `PreToolUse` enforcer (from `policies:`) is the hard
+  backstop; this is feedback.
+
+Kill switch: `OMA_DISABLE_AUDIT=1`. Like the other bundled hooks the script is
+self-contained (writes only under `.omao/`, no repo-root dependency) and
+requires a real JSON encoder so attacker-influenced tool inputs cannot corrupt
+the JSON-L line or the emitted payload.
+
+This tool-level log is distinct from `.omao/audit.jsonl`
+([`event.schema.json`](https://github.com/aws-samples/sample-oh-my-aidlcops/blob/main/schemas/audit/event.schema.json)),
+which records semantic ontology decisions (`approve`/`deploy`/`gate-pass`)
+against the eight ontology entities via `tools.oma_audit.append`.
+
 ## Backward compatibility guarantees
 
 - v1 files continue to validate under the same `dsl.schema.json`.

--- a/docs/docs/harness-engineering.md
+++ b/docs/docs/harness-engineering.md
@@ -94,6 +94,20 @@ OMA reflects this in its review lane: distinct reviewer roles (security, quality
 code) run as separate agents, and `continuous-eval` re-checks deployed behavior
 against regression datasets rather than trusting the generating agent's own tests.
 
+## Audit as a harness property, not an agent chore
+
+An audit trail the agent has to *remember* to write is not a control — the runs
+that most need recording are exactly the ones a runaway agent skips. The
+`agenticops` plugin bundles a `PostToolUse` hook (`audit-posttooluse.sh`) that
+records **every** tool call to `.omao/audit/tool-events.jsonl` at the harness
+level, and returns a non-blocking nudge on state-changing calls (mutating
+`kubectl`/`aws`/`terraform`/`helm`, `Write`, `Edit`, …) to record the semantic
+ontology event and re-check gates. Because it fires from the harness, the log
+exists whether or not the agent invokes the `audit-trail` skill. `PostToolUse`
+cannot block (the tool already ran), so this complements — never replaces — the
+`PreToolUse` policy enforcer. Kill switch: `OMA_DISABLE_AUDIT=1`. See
+[Harness DSL v2 → Tool-call auditing](./harness-dsl-v2.md#tool-call-auditing-post-tool-use).
+
 ## How the two axes close the loop
 
 Ontology defines constraints → harness verifies/enforces them → verification

--- a/plugins/agenticops/agenticops.oma.yaml
+++ b/plugins/agenticops/agenticops.oma.yaml
@@ -92,6 +92,24 @@ policies:
       reason: "Harness: writing secret-bearing files via the shell is blocked. Use a secrets manager (e.g. External Secrets, SSM) instead of committing secrets."
 
 # ---------------------------------------------------------------------------
+# Hooks — plugin-bundled, self-contained.
+#   post-tool-use: after every tool call, audit-posttooluse.sh appends a
+#     tool-level record to .omao/audit/tool-events.jsonl (conforming to
+#     schemas/audit/tool-event.schema.json) and, for state-changing calls
+#     (mutating kubectl / aws / terraform / helm / fs, Write, Edit), returns an
+#     additionalContext nudge to record the semantic event and check gates.
+#     Makes the audit trail a property of the harness, not of the agent
+#     remembering to call the audit-trail skill. PostToolUse cannot block, so
+#     this is feedback; the PreToolUse enforcer above is the hard backstop.
+#     Kill switch: OMA_DISABLE_AUDIT=1.
+# The compiler emits the PostToolUse entry into hooks/hooks.json from this
+# declaration; do not hand-edit that entry.
+# ---------------------------------------------------------------------------
+hooks:
+  post-tool-use:
+    runs: hooks/audit-posttooluse.sh
+
+# ---------------------------------------------------------------------------
 # Keyword triggers for Tier-0 routing.
 # ---------------------------------------------------------------------------
 triggers:

--- a/plugins/agenticops/hooks/audit-posttooluse.sh
+++ b/plugins/agenticops/hooks/audit-posttooluse.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# audit-posttooluse.sh — plugin-bundled PostToolUse audit hook (harness safety axis).
+#
+# Runs AFTER every tool call succeeds. Two jobs:
+#   1. AUDIT (all tools): append one JSON-L line per call to
+#      .omao/audit/tool-events.jsonl, conforming to
+#      schemas/audit/tool-event.schema.json. This makes the audit trail a
+#      property of the harness, not of the agent remembering to call the
+#      audit-trail skill.
+#   2. FEEDBACK (mutating tools only): return an additionalContext nudge so the
+#      agent is reminded to record a semantic ontology event / check gates after
+#      a state-changing action. PostToolUse cannot block (the tool already ran),
+#      so this is guidance, not enforcement — see the PreToolUse enforcer for the
+#      hard backstop.
+#
+# SELF-CONTAINED BY DESIGN (same contract as session-start-ontology.sh /
+# stop-gate.sh): writes only under the project's .omao/ and has NO repo-root or
+# jsonschema dependency, so it works verbatim from an installed plugin copy and
+# emits schema-conforming lines with just jq (python3 fallback).
+#
+# CONTROLS:
+#   OMA_DISABLE_AUDIT=1   kill switch — pass through, write nothing.
+#
+# A real JSON encoder is REQUIRED: tool inputs are attacker-influenced
+# (file contents, commands) and naive shell interpolation would corrupt the
+# JSON-L line or the emitted hook payload.
+#
+# Emitted into hooks/hooks.json (PostToolUse) by oma-compile from the DSL
+# `hooks.post-tool-use` declaration. Do not hand-edit that entry; edit the DSL
+# and recompile.
+
+set -euo pipefail
+
+_emit_pass() {
+  # Valid no-op PostToolUse payload (no feedback).
+  printf '{}\n'
+  exit 0
+}
+
+# Kill switch.
+if [[ "${OMA_DISABLE_AUDIT:-0}" == "1" ]]; then
+  _emit_pass
+fi
+
+# A JSON encoder is mandatory. Without jq we cannot safely parse the event or
+# emit a conforming line, so we pass through rather than write corrupt audit.
+if ! command -v jq >/dev/null 2>&1; then
+  _emit_pass
+fi
+
+INPUT="$(cat 2>/dev/null || true)"
+[[ -z "$INPUT" ]] && _emit_pass
+
+TOOL="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")"
+[[ -z "$TOOL" ]] && _emit_pass
+
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")"
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")"
+# Edit/Write/Read use file_path; NotebookEdit uses notebook_path.
+FILE_PATH="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null || echo "")"
+
+# --- classify: is this a state-mutating call? -------------------------------
+# Mutating pattern rules. First match wins and names the rule for the record.
+CLASSIFICATION="benign"
+MATCHED_RULE=""
+
+case "$TOOL" in
+  Write|NotebookEdit)
+    CLASSIFICATION="mutating"; MATCHED_RULE="file-write" ;;
+  Edit)
+    CLASSIFICATION="mutating"; MATCHED_RULE="file-edit" ;;
+  Bash)
+    # Ordered command-pattern checks. Kept intentionally broad; the audit line
+    # records which rule fired so downstream review can tune.
+    if   [[ "$COMMAND" =~ kubectl[[:space:]]+(apply|create|delete|edit|patch|replace|scale|autoscale|set|rollout|expose|run|annotate|label|taint|cordon|drain|uncordon) ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="kubectl-mutating"
+    elif [[ "$COMMAND" =~ aws[[:space:]]+[a-z0-9-]+[[:space:]]+(delete|put|update|create|remove|terminate|deregister|detach|disable|modify|reboot|stop)- ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="aws-cli-mutating"
+    elif [[ "$COMMAND" =~ terraform[[:space:]]+(apply|destroy) ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="terraform-mutating"
+    elif [[ "$COMMAND" =~ helm[[:space:]]+(install|upgrade|uninstall|delete|rollback) ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="helm-mutating"
+    elif [[ "$COMMAND" =~ (^|[[:space:]\;\|&])(rm|mv|cp|dd|truncate|chmod|chown)[[:space:]] ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="fs-mutating"
+    elif [[ "$COMMAND" =~ git[[:space:]]+(push|reset|clean|rebase) ]]; then
+      CLASSIFICATION="mutating"; MATCHED_RULE="git-mutating"
+    fi
+    ;;
+esac
+
+FEEDBACK_EMITTED=false
+[[ "$CLASSIFICATION" == "mutating" ]] && FEEDBACK_EMITTED=true
+
+# --- append the audit line (all tools) --------------------------------------
+OMA_PROJ_DIR="${CLAUDE_PROJECT_DIR:-${OMA_PROJECT_DIR:-$PWD}}"
+AUDIT_DIR="$OMA_PROJ_DIR/.omao/audit"
+AUDIT_FILE="$AUDIT_DIR/tool-events.jsonl"
+TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+# Truncate the command excerpt to keep lines small and within the schema bound.
+COMMAND_EXCERPT="${COMMAND:0:512}"
+
+# Build the record with jq so every value is correctly escaped. Optional keys
+# are dropped when empty to keep the line minimal and schema-conforming.
+mkdir -p "$AUDIT_DIR" 2>/dev/null || true
+if RECORD="$(jq -cn \
+    --arg ts "$TS" \
+    --arg tool "$TOOL" \
+    --arg classification "$CLASSIFICATION" \
+    --arg matched_rule "$MATCHED_RULE" \
+    --arg command_excerpt "$COMMAND_EXCERPT" \
+    --arg file_path "$FILE_PATH" \
+    --arg session_id "$SESSION_ID" \
+    --arg cwd "$CWD" \
+    --argjson feedback_emitted "$FEEDBACK_EMITTED" '
+      {ts: $ts, tool: $tool, classification: $classification, feedback_emitted: $feedback_emitted}
+      + (if $matched_rule    != "" then {matched_rule: $matched_rule}       else {} end)
+      + (if $command_excerpt != "" then {command_excerpt: $command_excerpt} else {} end)
+      + (if $file_path       != "" then {file_path: $file_path}             else {} end)
+      + (if $session_id      != "" then {session_id: $session_id}           else {} end)
+      + (if $cwd             != "" then {cwd: $cwd}                         else {} end)
+    ' 2>/dev/null)"; then
+  # Append-only; open(a) is atomic for small writes on POSIX.
+  printf '%s\n' "$RECORD" >> "$AUDIT_FILE" 2>/dev/null || true
+fi
+
+# --- feedback (mutating only) -----------------------------------------------
+if [[ "$CLASSIFICATION" != "mutating" ]]; then
+  _emit_pass
+fi
+
+TARGET="$FILE_PATH"
+[[ -z "$TARGET" && -n "$COMMAND_EXCERPT" ]] && TARGET="$COMMAND_EXCERPT"
+
+CONTEXT="[OMA audit] Recorded a state-changing $TOOL call (rule: ${MATCHED_RULE:-n/a}) to .omao/audit/tool-events.jsonl.
+Target: ${TARGET:-n/a}
+If this mutated an ontology entity (Deployment, Incident, ...), record the semantic event with the audit-trail skill, and confirm no phase gate is blocked before proceeding."
+
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'

--- a/plugins/agenticops/hooks/hooks.json
+++ b/plugins/agenticops/hooks/hooks.json
@@ -10,5 +10,16 @@
         }
       ]
     }
+  ],
+  "PostToolUse": [
+    {
+      "_oma": "oma-audit-posttooluse",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/audit-posttooluse.sh\""
+        }
+      ]
+    }
   ]
 }

--- a/schemas/audit/tool-event.schema.json
+++ b/schemas/audit/tool-event.schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://aws-samples.github.io/sample-oh-my-aidlcops/schemas/audit/tool-event.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ToolAuditEvent",
+  "description": "One line of .omao/audit/tool-events.jsonl. A lightweight, tool-level audit record written by the agenticops PostToolUse hook (audit-posttooluse.sh) after every tool call. Distinct from event.schema.json, which records semantic ontology decisions (approve/deploy/gate-pass) against the 8 ontology entities. This record is self-contained (no $ref) so the hook can emit conforming lines with only jq or python3 at runtime — no jsonschema dependency inside the installed plugin.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ts", "tool", "classification"],
+  "properties": {
+    "ts": {
+      "description": "ISO 8601 UTC timestamp of when the hook recorded the event (post tool execution).",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    },
+    "tool": {
+      "description": "Claude Code tool name (e.g. Bash, Write, Edit, Read).",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "classification": {
+      "description": "Whether the call was recognized as state-mutating. `mutating` calls also get an additionalContext feedback nudge; `benign` calls are recorded only.",
+      "enum": ["mutating", "benign"]
+    },
+    "matched_rule": {
+      "description": "Id of the mutating-pattern rule that classified this call, when classification=mutating.",
+      "type": "string",
+      "maxLength": 64
+    },
+    "command_excerpt": {
+      "description": "First bytes of the Bash command (truncated). Recorded for Bash calls; may be omitted for other tools.",
+      "type": "string",
+      "maxLength": 512
+    },
+    "file_path": {
+      "description": "Target path for file tools (Write/Edit/Read/NotebookEdit).",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "session_id": {
+      "description": "Claude Code session id from the hook payload, when present.",
+      "type": "string",
+      "maxLength": 128
+    },
+    "cwd": {
+      "description": "Working directory reported by the hook payload, when present.",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "feedback_emitted": {
+      "description": "True when the hook returned an additionalContext nudge for this call.",
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/harness/dsl.schema.json
+++ b/schemas/harness/dsl.schema.json
@@ -63,7 +63,7 @@
       "additionalProperties": { "$ref": "#/definitions/mcpServer" }
     },
     "hooks": {
-      "description": "Harness hooks. Keys are Claude Code hook event names (session-start, pre-tool-use, ...).",
+      "description": "Harness hooks keyed by event name. The compiler emits a plugin-bundled hooks/hooks.json entry for each recognized event: session-start (ontology-state injection) and post-tool-use (tool-call auditing via the bundled audit-posttooluse.sh). Each runs path must stay inside the plugin root. PreToolUse is not declared here — it is derived from the policies: block.",
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/hook" }
     },

--- a/tests/audit/test_tool_event_schema.py
+++ b/tests/audit/test_tool_event_schema.py
@@ -1,0 +1,87 @@
+"""Tool-event audit schema tests (Draft 2020-12).
+
+The tool-event schema is self-contained (no $ref), so validation needs no
+registry — this mirrors the runtime contract where the PostToolUse hook emits
+conforming lines with only jq/python3.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = json.loads(
+    (REPO_ROOT / "schemas" / "audit" / "tool-event.schema.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(SCHEMA, format_checker=FormatChecker())
+
+
+MUTATING_BASH_OK = {
+    "ts": "2026-07-19T12:00:00Z",
+    "tool": "Bash",
+    "classification": "mutating",
+    "matched_rule": "kubectl-mutating",
+    "command_excerpt": "kubectl apply -f manifest.yaml",
+    "session_id": "sess-123",
+    "cwd": "/home/user/project",
+    "feedback_emitted": True,
+}
+
+BENIGN_READ_OK = {
+    "ts": "2026-07-19T12:01:00Z",
+    "tool": "Read",
+    "classification": "benign",
+    "file_path": "/home/user/project/README.md",
+    "feedback_emitted": False,
+}
+
+MUTATING_WRITE_OK = {
+    "ts": "2026-07-19T12:02:00Z",
+    "tool": "Write",
+    "classification": "mutating",
+    "matched_rule": "file-write",
+    "file_path": "/home/user/project/main.py",
+    "feedback_emitted": True,
+}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [MUTATING_BASH_OK, BENIGN_READ_OK, MUTATING_WRITE_OK],
+    ids=["mutating-bash", "benign-read", "mutating-write"],
+)
+def test_positive(payload):
+    errs = list(_validator().iter_errors(payload))
+    assert errs == [], [e.message for e in errs]
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        # Missing required ts
+        ({"tool": "Bash", "classification": "benign"}, "ts"),
+        # Missing required classification
+        ({"ts": "2026-07-19T12:00:00Z", "tool": "Bash"}, "classification"),
+        # Bad timestamp
+        ({"ts": "yesterday", "tool": "Bash", "classification": "benign"}, "pattern"),
+        # Unknown classification
+        ({"ts": "2026-07-19T12:00:00Z", "tool": "Bash",
+          "classification": "destructive"}, "destructive"),
+        # Unknown top-level property (additionalProperties: false)
+        ({"ts": "2026-07-19T12:00:00Z", "tool": "Bash",
+          "classification": "benign", "rogue": "x"}, "rogue"),
+    ],
+    ids=["missing-ts", "missing-class", "bad-ts", "unknown-class", "extra-prop"],
+)
+def test_negative(payload, expected):
+    errs = list(_validator().iter_errors(payload))
+    assert errs, f"expected schema violations for {expected}"

--- a/tests/harness/test_post_tool_use_emit.py
+++ b/tests/harness/test_post_tool_use_emit.py
@@ -1,0 +1,115 @@
+"""Compiler PostToolUse emission tests.
+
+The compiler emits a plugin-bundled PostToolUse entry into hooks/hooks.json from
+a DSL `hooks.post-tool-use.runs` declaration, so /plugin install delivers
+tool-call auditing. It must coexist with the policies-derived PreToolUse entry
+(each re-owns only its own _oma-marked entry). The runs path must stay inside
+the plugin root (the same plugin-escape guard as SessionStart).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.oma_compile.compile import (
+    HARNESS_HOOK_MARKER,
+    POST_TOOL_USE_MARKER,
+    CompileError,
+    _build_hooks_json,
+    compile_plugin,
+)
+
+
+def _write_plugin(root: Path, dsl: dict) -> Path:
+    plugin_dir = root / "plugins" / dsl["plugin"]
+    (plugin_dir / "hooks").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "hooks" / "audit-posttooluse.sh").write_text(
+        "#!/usr/bin/env bash\n", encoding="utf-8"
+    )
+    out = plugin_dir / f"{dsl['plugin']}.oma.yaml"
+    out.write_text(yaml.safe_dump(dsl, sort_keys=False), encoding="utf-8")
+    return out
+
+
+BASE_DSL = {
+    "version": 2,
+    "plugin": "x-plugin",
+    "mcp": {},
+    "agents": [],
+    "hooks": {"post-tool-use": {"runs": "hooks/audit-posttooluse.sh"}},
+}
+
+
+def test_post_tool_use_entry_emitted(tmp_path):
+    dsl_path = _write_plugin(tmp_path, BASE_DSL)
+    compile_plugin(dsl_path, write=True)
+    hooks_json = json.loads(
+        (dsl_path.parent / "hooks" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert hooks_json["PostToolUse"][0]["_oma"] == POST_TOOL_USE_MARKER
+    assert hooks_json["PostToolUse"][0]["hooks"][0]["command"] == (
+        'bash "${CLAUDE_PLUGIN_ROOT}/hooks/audit-posttooluse.sh"'
+    )
+
+
+def test_coexists_with_policies_pretooluse(tmp_path):
+    """A policies-derived PreToolUse and a hooks-declared PostToolUse coexist."""
+    dsl = dict(BASE_DSL)
+    dsl["policies"] = [
+        {"id": "r", "enforce": {"tool": "Write", "deny_if": {"file_path_matches": "x"}}}
+    ]
+    payload = _build_hooks_json(dsl, None, tmp_path / "x.oma.yaml")
+    assert payload["PreToolUse"][0]["_oma"] == HARNESS_HOOK_MARKER
+    assert payload["PostToolUse"][0]["_oma"] == POST_TOOL_USE_MARKER
+
+
+def test_escaping_runs_path_rejected(tmp_path):
+    dsl = dict(BASE_DSL)
+    dsl["hooks"] = {"post-tool-use": {"runs": "../../hooks/audit-posttooluse.sh"}}
+    dsl_path = _write_plugin(tmp_path, dsl)
+    (tmp_path / "hooks").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "hooks" / "audit-posttooluse.sh").write_text(
+        "#!/bin/bash\n", encoding="utf-8"
+    )
+    with pytest.raises(CompileError, match="escapes the plugin root"):
+        compile_plugin(dsl_path, write=True)
+
+
+def test_hand_authored_post_tool_use_preserved(tmp_path):
+    existing = {
+        "PostToolUse": [
+            {"hooks": [{"type": "command", "command": "echo hand-authored"}]},
+            {
+                "_oma": POST_TOOL_USE_MARKER,
+                "hooks": [{"type": "command", "command": "STALE"}],
+            },
+        ]
+    }
+    payload = _build_hooks_json(BASE_DSL, existing, tmp_path / "x.oma.yaml")
+    commands = [e["hooks"][0]["command"] for e in payload["PostToolUse"]]
+    assert "echo hand-authored" in commands
+    assert 'bash "${CLAUDE_PLUGIN_ROOT}/hooks/audit-posttooluse.sh"' in commands
+    assert "STALE" not in commands
+    assert sum(
+        1 for e in payload["PostToolUse"] if e.get("_oma") == POST_TOOL_USE_MARKER
+    ) == 1
+
+
+def test_dropping_declaration_removes_managed_keeps_hand_authored(tmp_path):
+    existing = {
+        "PostToolUse": [
+            {"hooks": [{"type": "command", "command": "echo hand-authored"}]},
+            {
+                "_oma": POST_TOOL_USE_MARKER,
+                "hooks": [{"type": "command", "command": "STALE"}],
+            },
+        ]
+    }
+    dsl = {"version": 2, "plugin": "x-plugin", "hooks": {}}
+    payload = _build_hooks_json(dsl, existing, tmp_path / "x.oma.yaml")
+    commands = [e["hooks"][0]["command"] for e in payload["PostToolUse"]]
+    assert commands == ["echo hand-authored"]

--- a/tests/hooks/test_audit_posttooluse.bats
+++ b/tests/hooks/test_audit_posttooluse.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/hooks/test_audit_posttooluse.bats
+#
+# Behavioral tests for the plugin-bundled PostToolUse audit hook. It records
+# every tool call to .omao/audit/tool-events.jsonl and returns an
+# additionalContext nudge only for state-changing calls.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK="$REPO_ROOT/plugins/agenticops/hooks/audit-posttooluse.sh"
+    PROJECT="$(mktemp -d)"
+    LOG="$PROJECT/.omao/audit/tool-events.jsonl"
+}
+
+teardown() {
+    rm -rf "$PROJECT"
+}
+
+_run() {
+    run env CLAUDE_PROJECT_DIR="$PROJECT" bash "$HOOK" <<<"$1"
+}
+
+@test "benign Read: recorded, no feedback" {
+    _run '{"tool_name":"Read","tool_input":{"file_path":"/x/README.md"}}'
+    [ "$status" -eq 0 ]
+    # No additionalContext (empty payload).
+    echo "$output" | jq -e 'has("hookSpecificOutput") | not' >/dev/null
+    [ -f "$LOG" ]
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.tool == "Read" and .classification == "benign"' >/dev/null
+}
+
+@test "mutating kubectl apply: recorded + feedback" {
+    _run '{"tool_name":"Bash","tool_input":{"command":"kubectl apply -f m.yaml"}}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"' >/dev/null
+    echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("state-changing")' >/dev/null
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.classification == "mutating" and .matched_rule == "kubectl-mutating"' >/dev/null
+}
+
+@test "Write: classified mutating with feedback" {
+    _run '{"tool_name":"Write","tool_input":{"file_path":"/x/main.py"}}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"' >/dev/null
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.tool == "Write" and .matched_rule == "file-write" and .file_path == "/x/main.py"' >/dev/null
+}
+
+@test "benign bash (ls): recorded, no feedback" {
+    _run '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("hookSpecificOutput") | not' >/dev/null
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.classification == "benign"' >/dev/null
+}
+
+@test "aws delete: classified mutating" {
+    _run '{"tool_name":"Bash","tool_input":{"command":"aws s3api delete-bucket --bucket x"}}'
+    [ "$status" -eq 0 ]
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.matched_rule == "aws-cli-mutating"' >/dev/null
+}
+
+@test "terraform destroy: classified mutating" {
+    _run '{"tool_name":"Bash","tool_input":{"command":"terraform destroy -auto-approve"}}'
+    [ "$status" -eq 0 ]
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.matched_rule == "terraform-mutating"' >/dev/null
+}
+
+@test "OMA_DISABLE_AUDIT=1: no record, no feedback" {
+    run env CLAUDE_PROJECT_DIR="$PROJECT" OMA_DISABLE_AUDIT=1 bash "$HOOK" \
+        <<<'{"tool_name":"Write","tool_input":{"file_path":"/x/y"}}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("hookSpecificOutput") | not' >/dev/null
+    [ ! -f "$LOG" ]
+}
+
+@test "crafted command with quotes/newline: output and log stay valid JSON" {
+    _run '{"tool_name":"Bash","tool_input":{"command":"echo \"evil\" && rm -rf /tmp/x\nnl"}}'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"' >/dev/null
+    # The appended line must parse as a single JSON object.
+    run tail -n1 "$LOG"
+    echo "$output" | jq -e '.tool == "Bash"' >/dev/null
+}
+
+@test "every recorded line has required fields" {
+    _run '{"tool_name":"Read","tool_input":{"file_path":"/a"}}'
+    _run '{"tool_name":"Write","tool_input":{"file_path":"/b"}}'
+    _run '{"tool_name":"Bash","tool_input":{"command":"kubectl delete pod x"}}'
+    run wc -l < "$LOG"
+    [ "$output" -eq 3 ]
+    # Each line must carry ts, tool, classification.
+    while IFS= read -r line; do
+        echo "$line" | jq -e 'has("ts") and has("tool") and has("classification")' >/dev/null
+    done < "$LOG"
+}

--- a/tools/oma_compile/compile.py
+++ b/tools/oma_compile/compile.py
@@ -297,11 +297,17 @@ HARNESS_HOOK_MARKER = "oma-harness-enforce"
 # Marker for the compiler-managed SessionStart entry (#60). Same re-own pattern
 # as the harness marker so hand-authored SessionStart hooks are preserved.
 SESSION_START_MARKER = "oma-session-start"
+# Marker for the compiler-managed PostToolUse audit entry. Its own marker keeps
+# re-own scoped per event so hand-authored PostToolUse hooks survive recompiles.
+POST_TOOL_USE_MARKER = "oma-audit-posttooluse"
 
 # DSL hook events the compiler emits into hooks/hooks.json, mapped to the
-# Claude Code hook event name. PreToolUse is handled separately (it is derived
-# from policies:, not from a hooks: declaration).
-_EMITTABLE_HOOK_EVENTS = {"session-start": "SessionStart"}
+# (Claude Code hook event name, re-own marker) it manages. PreToolUse is handled
+# separately (it is derived from policies:, not from a hooks: declaration).
+_EMITTABLE_HOOK_EVENTS = {
+    "session-start": ("SessionStart", SESSION_START_MARKER),
+    "post-tool-use": ("PostToolUse", POST_TOOL_USE_MARKER),
+}
 
 
 def _plugin_relative_hook_command(runs: str, source: Path) -> str:
@@ -328,8 +334,9 @@ def _build_hooks_json(dsl: dict, existing: dict | None, source: Path) -> dict | 
     Manages two entry kinds, both re-owned via an _oma marker so hand-authored
     entries survive recompiles:
       * PreToolUse — the harness enforcer, emitted when policies: is present.
-      * SessionStart — emitted when hooks.session-start.runs is declared (#60),
-        so ontology-state injection ships inside the plugin.
+      * SessionStart / PostToolUse — emitted when the matching hooks.<event>.runs
+        is declared, so ontology-state injection (#60, SessionStart) and
+        tool-call auditing (PostToolUse) ship inside the plugin.
 
     Returns the new payload, or None when nothing is managed and nothing was
     hand-authored.
@@ -356,18 +363,20 @@ def _build_hooks_json(dsl: dict, existing: dict | None, source: Path) -> dict | 
     else:
         payload.pop("PreToolUse", None)
 
-    # SessionStart (and any other emittable hooks:) — from the hooks: block.
+    # SessionStart / PostToolUse (and any other emittable hooks:) — from the
+    # hooks: block. Each event re-owns only its own marked entry, so
+    # hand-authored entries in the same group survive recompiles.
     hooks = dsl.get("hooks") or {}
-    for event, cc_event in _EMITTABLE_HOOK_EVENTS.items():
+    for event, (cc_event, marker) in _EMITTABLE_HOOK_EVENTS.items():
         managed = [
             e for e in (payload.get(cc_event) or [])
-            if e.get("_oma") != SESSION_START_MARKER
+            if e.get("_oma") != marker
         ]
         spec = hooks.get(event) or {}
         runs = spec.get("runs")
         if runs:
             entry = {
-                "_oma": SESSION_START_MARKER,
+                "_oma": marker,
                 "hooks": [{
                     "type": "command",
                     "command": _plugin_relative_hook_command(runs, source),


### PR DESCRIPTION
## Summary

Adds a plugin-bundled `PostToolUse` hook to the `agenticops` plugin so the audit
trail becomes a **property of the harness** rather than something the agent has
to remember to do. After every tool call it appends a record to
`.omao/audit/tool-events.jsonl`, and for state-changing calls it returns a
non-blocking nudge to record the semantic ontology event and re-check gates.

## Why

An audit trail the agent has to *remember* to write is not a control — the runs
that most need recording (destructive commands, file mutations) are exactly the
ones a runaway agent skips. Wiring the record at the harness level means the log
exists whether or not the agent invokes the `audit-trail` skill. Because
`PostToolUse` fires *after* the tool runs, it cannot block — so this **complements,
never replaces**, the `PreToolUse` policy enforcer (the hard backstop).

## What it does

- **Audit (all tools)** — appends one JSON-L line per tool call to
  `.omao/audit/tool-events.jsonl`, conforming to
  `schemas/audit/tool-event.schema.json`.
- **Feedback (state-changing calls only)** — for mutating patterns
  (`Write`, `Edit`, mutating `kubectl`, `aws` delete/put/update/…,
  `terraform apply|destroy`, `helm` install/upgrade/…, `rm|mv|cp|…`,
  `git push|reset|…`), returns an `additionalContext` nudge to record the
  semantic ontology event and confirm no phase gate is blocked.

Classification is recorded per line (`benign` vs `mutating`, with the matched
rule id), so downstream review can see exactly why a call was flagged.

Kill switch: `OMA_DISABLE_AUDIT=1`.

## Design decisions

- **Separate lightweight schema.** `schemas/audit/tool-event.schema.json` is a
  new, self-contained (no `$ref`) tool-level record — distinct from
  `event.schema.json`, which records *semantic ontology decisions*
  (`approve`/`deploy`/`gate-pass`) against the eight ontology entities via
  `tools.oma_audit.append`. Being `$ref`-free lets the hook emit conforming lines
  with only `jq` (or `python3`) — **no `jsonschema` dependency inside the
  installed plugin**.
- **Self-contained hook.** `audit-posttooluse.sh` writes only under `.omao/`, has
  no repo-root dependency, and requires a real JSON encoder so
  attacker-influenced tool inputs (commands, file contents) cannot corrupt the
  JSON-L line or the emitted payload.
- **Coexists with PreToolUse.** The policies-derived `PreToolUse` entry and this
  `hooks:`-declared `PostToolUse` entry live in the same `hooks.json`; each
  re-owns only its own `_oma`-marked entry, so recompiles preserve both.

---

*Issue #, if available:*

---

*Description of changes:*

## Implementation

- **`plugins/agenticops/hooks/audit-posttooluse.sh`** (new) — the hook.
- **`schemas/audit/tool-event.schema.json`** (new) — the tool-event record schema.
- **`tools/oma_compile/compile.py`** — `_EMITTABLE_HOOK_EVENTS` becomes an
  `{event: (cc_event, marker)}` map; adds `post-tool-use → PostToolUse` with its
  own `_oma` marker.
- **`plugins/agenticops/agenticops.oma.yaml`** — declares `hooks.post-tool-use`;
  `hooks.json` recompiled.
- **schema + docs** — document the new hook event and the tool-event log.

## Tests

- `tests/audit/test_tool_event_schema.py` — 8 schema cases (positive + negative).
- `tests/harness/test_post_tool_use_emit.py` — 5 compiler-emit cases, including
  coexistence with the policies-derived `PreToolUse` entry and per-marker re-own.
- `tests/hooks/test_audit_posttooluse.bats` — 9 behavior cases: benign vs
  mutating classification (kubectl/aws/terraform/Write/Edit), feedback only on
  mutating, `OMA_DISABLE_AUDIT=1`, injection-safe JSON, required fields per line.

Results: pytest green · bats 9/9 · `oma compile --all --check` clean.

Verified end-to-end in Claude Code 2.1.214: a session that wrote/read/edited
files produced the expected lines in `.omao/audit/tool-events.jsonl`
(`Write`/`Edit` → `mutating`, `Read`/`Bash` → `benign`), with the mutating-call
nudge surfaced to the agent.

## Dependency / ordering note

This branch's emitted `hooks.json` uses the historical top-level event-name shape
(`{"PostToolUse": [...], "PreToolUse": [...]}`). Claude Code 2.1.x requires the
event map wrapped under a top-level `hooks` key, so on its own the bundled hook is
rejected at install time. That wrapper fix is a **separate, orthogonal change**
(see the companion `fix(harness): wrap plugin hooks.json under a top-level "hooks"
key` PR). Once both land, recompiling produces the wrapped shape and this
PostToolUse entry loads correctly — verified in Claude Code 2.1.214 with the
wrapper fix applied.

Recommended merge order: land the `hooks.json` wrapper fix first (or fold this
branch on top of it), then this feature, so `main` never carries a `hooks.json`
that CC 2.x rejects.

## Changed files

```
plugins/agenticops/hooks/audit-posttooluse.sh  (new)   self-contained PostToolUse hook
schemas/audit/tool-event.schema.json           (new)   lightweight tool-level record schema
tools/oma_compile/compile.py                            emit post-tool-use event
plugins/agenticops/agenticops.oma.yaml                  declare hooks.post-tool-use
plugins/agenticops/hooks/hooks.json                     recompiled (PostToolUse entry)
schemas/harness/dsl.schema.json                         document hook event
docs/docs/harness-dsl-v2.md                             Tool-call auditing section
docs/docs/harness-engineering.md                        audit-as-harness-property note
tests/audit/test_tool_event_schema.py          (new)    8 schema tests
tests/harness/test_post_tool_use_emit.py       (new)    5 compiler-emit tests
tests/hooks/test_audit_posttooluse.bats        (new)    9 behavior tests
```

## Compatibility

- Additive: plugins without `hooks.post-tool-use` are unaffected; the new
  tool-event schema is separate from the existing audit event schema.
- Absent `.omao/`, the hook creates only `.omao/audit/` for its log and otherwise
  passes through, so it never blocks a tool (PostToolUse cannot block by design).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
